### PR TITLE
fix(dnd-builder): fix padding issue on report builder

### DIFF
--- a/src/styles/_jfReportsViewModes.scss
+++ b/src/styles/_jfReportsViewModes.scss
@@ -24,7 +24,7 @@
 
 .jfReport.customizeMode {
   .jfReport-canvas {
-    padding: 0 88px;
+    padding: 0 120px;
   }
 
   .jfReport-page {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**
Ticket Link: https://www.jotform.com/answers/4834139-report-builder-slide-settings-ui-issue 

There was a bug on report builder. On mobile, user can't scroll as far to the left to see the settings buttons for the first slide.

before fix:
<img width="575" alt="Screenshot 2023-04-10 at 10 19 07 AM" src="https://user-images.githubusercontent.com/106732879/230848978-3237cda5-c9fe-4513-98f2-76a9fbed5f43.png">

**:

<!-- Why are these changes necessary? -->

**Users cannot interact with the  first slide settings buttons in mobile view. This needs to be fixed.**:

<!-- How were these changes implemented? -->

**Normally there was a padding of "0 88px" in the related element. This has been increased to "0 120px" and now the user can slide far enough to see the buttons.

<img width="364" alt="Screenshot 2023-04-09 at 8 53 33 PM" src="https://user-images.githubusercontent.com/106732879/230849323-e7c2ac6a-2bc3-4408-82be-83e19593f0a5.png">
**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the docs site N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->