### PR TITLE
fix(dnd-builder): escape escape key

### DIFF
--- a/src/components/Builder/Scene.js
+++ b/src/components/Builder/Scene.js
@@ -360,8 +360,7 @@ const Scene = ({
   const handleKeyboardEvent = e => {
     const shouldPaste = itemToPaste && e.key === 'v' && e.metaKey;
 
-    if (shouldSuppressKeyboardEvent(e))
-    {
+    if (shouldSuppressKeyboardEvent(e)) {
       return; 
     }
 

--- a/src/components/Builder/Scene.js
+++ b/src/components/Builder/Scene.js
@@ -361,7 +361,7 @@ const Scene = ({
     const shouldPaste = itemToPaste && e.key === 'v' && e.metaKey;
 
     if (shouldSuppressKeyboardEvent(e)) {
-      return; 
+      return;
     }
 
     if (activeElement && !shouldPaste) {

--- a/src/components/Builder/Scene.js
+++ b/src/components/Builder/Scene.js
@@ -33,6 +33,7 @@ import {
 import { useEventListener } from '../../utils/hooks';
 import DraggableItemLayer from '../DraggableItem/DraggableItemLayer';
 import generateId from '../../utils/generateId';
+import { EVENT_IGNORED_ROLES } from '../../constants/eventIgnoredRoles';
 
 const Scene = ({
   additionalPageItems,
@@ -352,8 +353,17 @@ const Scene = ({
     }
   };
 
+  const shouldSuppressKeyboardEvent = e => (
+    EVENT_IGNORED_ROLES.some(role => e.target.closest(`[role=${role}]`))
+  );
+
   const handleKeyboardEvent = e => {
     const shouldPaste = itemToPaste && e.key === 'v' && e.metaKey;
+
+    if (shouldSuppressKeyboardEvent(e))
+    {
+      return; 
+    }
 
     if (activeElement && !shouldPaste) {
       const arrowKeyCodes = ['ArrowLeft', 'ArrowUp', 'ArrowDown', 'ArrowBottom'];

--- a/src/components/withClickOutside.js
+++ b/src/components/withClickOutside.js
@@ -1,9 +1,6 @@
 import { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
-
-const IGNORED_ROLES = [
-  'dialog',
-];
+import { EVENT_IGNORED_ROLES } from '../constants/eventIgnoredRoles';
 
 function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component';
@@ -27,7 +24,7 @@ function withClickOutside(WrappedComponent) {
           classList.contains(exceptionalClasses)
           || Array.from(classList).some(xClass => exceptionalClasses.includes(xClass))
           || exceptionalClasses.some(item => event.target.closest(`.${item}`))
-          || IGNORED_ROLES.some(role => event.target.closest(`[role=${role}]`))
+          || EVENT_IGNORED_ROLES.some(role => event.target.closest(`[role=${role}]`))
         )
       ) {
         return;

--- a/src/constants/eventIgnoredRoles.js
+++ b/src/constants/eventIgnoredRoles.js
@@ -1,0 +1,8 @@
+/**
+ * If an HTML Tag has its role attribute set as one of the
+ * members of this array, events that originate from it
+ * should be ignored by event handlers.
+ */
+export const EVENT_IGNORED_ROLES = [
+  'dialog'
+];

--- a/src/constants/eventIgnoredRoles.js
+++ b/src/constants/eventIgnoredRoles.js
@@ -4,5 +4,5 @@
  * should be ignored by event handlers.
  */
 export const EVENT_IGNORED_ROLES = [
-  'dialog'
+  'dialog',
 ];


### PR DESCRIPTION
Escape escape key actions so they won't affect sidebar on dialog