### PR TITLE
fix(dnd-builder): fix same time multi backends error

### DIFF
--- a/src/components/Builder/DndWrapper.js
+++ b/src/components/Builder/DndWrapper.js
@@ -28,6 +28,7 @@ const DndWrapper = ({ children }) => {
   return (
     <DndProvider
       backend={MultiBackend}
+      context={window}
       options={HTML5toTouch}
     >
       {children}


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**After react 18 migration** . Faced `cannot have two MultiBackends at the same time` error. 

<img width="1153" alt="Uncaught runtime errors" src="https://github.com/user-attachments/assets/5df78cc3-e7a9-4178-ae96-5953b7d0a954">

**What**:

<!-- Why are these changes necessary? -->

This issue is related with react-dnd. Found [this issue](https://github.com/react-dnd/react-dnd/issues/3257) for resolving this bug. I guess this is creating bug because of DndProvider is not top level wrapper. In every routes changes it's creating new dnd provider. When i passed window as a context according to this issue. It's fixing the bug.

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation added to the docs site
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->