### PR TITLE
refactor: draggableItem actions and rendering

### DIFF
--- a/src/components/Settings/PageLayer/LayerDragOverlay.js
+++ b/src/components/Settings/PageLayer/LayerDragOverlay.js
@@ -13,7 +13,7 @@ const DragHandle = () => (
 );
 
 const LayerDragOverlay = ({
-  activeItemData = null,
+  activeItemData,
 }) => {
   const {
     CHART_ELEMENT,
@@ -22,8 +22,6 @@ const LayerDragOverlay = ({
     PAGE_ELEMENT,
     RECTANGLE,
   } = useTranslatedTexts();
-
-  if (!activeItemData) return null;
 
   const { icon: Icon, item } = activeItemData;
   const { id, isVisible } = item;
@@ -102,7 +100,7 @@ LayerDragOverlay.propTypes = {
       isVisible: PropTypes.bool,
       itemType: PropTypes.string,
     }),
-  }),
+  }).isRequired,
 };
 
 export default memo(LayerDragOverlay);

--- a/src/components/Settings/PageLayer/PageLayer.js
+++ b/src/components/Settings/PageLayer/PageLayer.js
@@ -109,7 +109,7 @@ const PageLayer = ({
             })}
           </ul>
         </SortableContext>
-        <LayerDragOverlay activeItemData={activeItemData} />
+        {activeItemData && <LayerDragOverlay activeItemData={activeItemData} />}
       </DndContext>
     ) : (
       <div className="toolSection-notifier">

--- a/src/components/TextEditor/CustomToolbar/CustomToolbarWrapper.js
+++ b/src/components/TextEditor/CustomToolbar/CustomToolbarWrapper.js
@@ -2,12 +2,9 @@ import { memo } from 'react';
 import PropTypes from 'prop-types';
 import CustomToolbar from './CustomToolbar';
 
-// This wrapper is needed to prevent the re-render
-// of the toolbar id div since it breaks the editor
 const CustomToolbarWrapper = ({
-  isTextEditorOpen = false,
   itemWidth = 0,
-}) => isTextEditorOpen && (
+}) => (
   <div
     id="toolbar"
     style={{
@@ -21,7 +18,6 @@ const CustomToolbarWrapper = ({
 );
 
 CustomToolbarWrapper.propTypes = {
-  isTextEditorOpen: PropTypes.bool,
   itemWidth: PropTypes.number,
 };
 


### PR DESCRIPTION
Moves item actions (delete, duplicate, lock) into a dedicated component for better organization and reusability.

Updates rendering logic to conditionally display resizer and actions based on item state (dragging, selection, lock).

Removes unused props and improves code clarity.
