### PR TITLE
refactor: active element management to support multiple selections

### DIFF
--- a/src/__tests__/unit-tests/Builder/RightPanel/rightPanelToggler.spec.js
+++ b/src/__tests__/unit-tests/Builder/RightPanel/rightPanelToggler.spec.js
@@ -25,9 +25,9 @@ describe('RightPanelToggler', () => {
     expect(eventMock).toHaveBeenCalledTimes(2);
   });
 
-  it('Should Call setActiveElement Once Click Right Panel Open Button', () => {
+  it('Should Call setActiveElements Once Click Right Panel Open Button', () => {
     const eventMock = jest.fn();
-    const rightPanelTogglerWrapper = mountWithProviders(<RightPanelToggler />, { builderProps: { setActiveElement: eventMock } });
+    const rightPanelTogglerWrapper = mountWithProviders(<RightPanelToggler />, { builderProps: { setActiveElements: eventMock } });
     const rightPanelOpenButton = rightPanelTogglerWrapper.find(selectors.rightPanelOpen);
     rightPanelOpenButton.simulate('click');
     expect(eventMock).toHaveBeenCalled();

--- a/src/__tests__/unit-tests/Builder/RightPanel/rightPanelToggler.spec.js
+++ b/src/__tests__/unit-tests/Builder/RightPanel/rightPanelToggler.spec.js
@@ -25,9 +25,9 @@ describe('RightPanelToggler', () => {
     expect(eventMock).toHaveBeenCalledTimes(2);
   });
 
-  it('Should Call setActiveElements Once Click Right Panel Open Button', () => {
+  it('Should Call resetActiveElements Once Click Right Panel Open Button', () => {
     const eventMock = jest.fn();
-    const rightPanelTogglerWrapper = mountWithProviders(<RightPanelToggler />, { builderProps: { setActiveElements: eventMock } });
+    const rightPanelTogglerWrapper = mountWithProviders(<RightPanelToggler />, { builderProps: { resetActiveElements: eventMock } });
     const rightPanelOpenButton = rightPanelTogglerWrapper.find(selectors.rightPanelOpen);
     rightPanelOpenButton.simulate('click');
     expect(eventMock).toHaveBeenCalled();

--- a/src/components/Builder/Element.js
+++ b/src/components/Builder/Element.js
@@ -21,7 +21,8 @@ const Element = ({
   const acceptedItems = usePropStore(state => state.acceptedItems);
   const onAnEventTrigger = usePropStore(state => state.onAnEventTrigger);
   const onItemAdd = usePropStore(state => state.onItemAdd);
-  const setActiveElement = useBuilderStore(state => state.setActiveElement);
+  const resetActiveElements = useBuilderStore(state => state.resetActiveElements);
+  const setActiveElements = useBuilderStore(state => state.setActiveElements);
   const setIsRightPanelOpen = useBuilderStore(state => state.setIsRightPanelOpen);
   const zoom = useBuilderStore(state => state.zoom);
 
@@ -31,7 +32,7 @@ const Element = ({
     }),
 
     item: () => {
-      setActiveElement(null);
+      resetActiveElements();
       return {
         itemType,
         type: DROPPABLE_ITEM_TYPE,
@@ -63,7 +64,7 @@ const Element = ({
       top,
     });
     onAnEventTrigger('reportItemAdd', itemType);
-    setActiveElement(itemID);
+    setActiveElements(itemID, true);
     setIsRightPanelOpen(true);
   };
 

--- a/src/components/Builder/Page.js
+++ b/src/components/Builder/Page.js
@@ -33,8 +33,8 @@ const Page = ({
   page = {},
   style = {},
 }) => {
-  const activeElement = useBuilderStore(state => state.activeElement);
-  const setActiveElement = useBuilderStore(state => state.setActiveElement);
+  const activeElements = useBuilderStore(state => state.activeElements);
+  const setActiveElements = useBuilderStore(state => state.setActiveElements);
   const setIsRightPanelOpen = useBuilderStore(state => state.setIsRightPanelOpen);
   const zoom = useBuilderStore(state => state.zoom);
   const isResize = useBuilderStore(state => state.isResize);
@@ -83,7 +83,7 @@ const Page = ({
     };
   };
 
-  const isMultipleItemSelected = activeElement !== null && activeElement.length > 1;
+  const isMultipleItemSelected = activeElements.length > 1;
 
   const onHover = (item, monitor) => {
     if (!requestRef.current) {
@@ -120,7 +120,7 @@ const Page = ({
           ...additionalData,
         });
         onAnEventTrigger('reportItemAdd', itemType);
-        setActiveElement(itemID);
+        setActiveElements(itemID);
         setIsRightPanelOpen(true);
         newCoords[itemID] = coords;
       } else if (type === DRAGGABLE_ITEM_TYPE) {
@@ -129,7 +129,7 @@ const Page = ({
         if (isMultipleItemSelected) {
           const leftDifference = additionalData.left - dragCoords.left;
           const topDifference = additionalData.top - dragCoords.top;
-          const _items = activeElement.reduce((acc, curr) => {
+          const _items = activeElements.reduce((acc, curr) => {
             const tempItem = findItemById(curr, pages);
             acc[curr] = {
               id: curr,

--- a/src/components/DraggableItem/DraggableItem.js
+++ b/src/components/DraggableItem/DraggableItem.js
@@ -245,8 +245,6 @@ const DraggableItem = ({
     width: stateWidth,
   }), [item, stateHeight, stateLeft, stateTop, stateWidth]);
 
-  console.log(activeElements);
-
   return (
     <ErrorBoundary>
       <ItemPositioner

--- a/src/components/DraggableItem/DraggableItem.js
+++ b/src/components/DraggableItem/DraggableItem.js
@@ -58,27 +58,26 @@ const DraggableItem = ({
   const onItemAdd = usePropStore(state => state.onItemAdd);
   const onItemResize = usePropStore(state => state.onItemResize);
 
-  const activeElement = useBuilderStore(state => state.activeElement);
-  const setActiveElement = useBuilderStore(state => state.setActiveElement);
+  const activeElements = useBuilderStore(state => state.activeElements);
+  const setActiveElements = useBuilderStore(state => state.setActiveElements);
   const setContextMenuProps = useBuilderStore(state => state.setContextMenuProps);
   const isTextEditorOpen = useBuilderStore(state => state.isTextEditorOpen);
   const setIsRightPanelOpen = useBuilderStore(state => state.setIsRightPanelOpen);
   const setIsResize = useBuilderStore(state => state.setIsResize);
 
-  const isSelected = isSelectedItem(item.id, activeElement);
-  const isMultipleItemSelected = activeElement !== null && activeElement.length > 1;
+  const isSelected = isSelectedItem(item.id, activeElements);
 
   const select = event => {
     if (!isSelected) {
-      if (!event || !event.metaKey) {
+      if (!event || !event.metaKey) { // Single item selected
+        setActiveElements(id, true);
         if (isLocked) {
-          setActiveElement(id, false);
           setIsRightPanelOpen(false);
-        } else {
-          setActiveElement(id);
         }
       } else {
-        setActiveElement(id, undefined, true);
+        // Multiple items selected
+        setActiveElements(id, false, false);
+        setIsRightPanelOpen(false);
       }
     }
   };
@@ -105,7 +104,7 @@ const DraggableItem = ({
       }
       removeEventListenerForSidebar();
     },
-    isDragging: () => (isMultipleItemSelected && isSelected) || (!isMultipleItemSelected && isSelected),
+    isDragging: () => isSelected,
     item: () => {
       select();
       addEventListenerForSidebar();
@@ -116,7 +115,6 @@ const DraggableItem = ({
     item,
     canDrag,
     id,
-    isMultipleItemSelected,
     isSelected,
   ]);
 
@@ -246,6 +244,8 @@ const DraggableItem = ({
     top: stateTop,
     width: stateWidth,
   }), [item, stateHeight, stateLeft, stateTop, stateWidth]);
+
+  console.log(activeElements);
 
   return (
     <ErrorBoundary>

--- a/src/components/DraggableItem/DraggableItemActions.js
+++ b/src/components/DraggableItem/DraggableItemActions.js
@@ -1,5 +1,5 @@
 import * as icons from '../../utils/icons';
-import { useActiveElement, useTranslatedTexts } from '../../utils/hooks';
+import { useSelectedElements, useTranslatedTexts } from '../../utils/hooks';
 import { usePropStore } from '../../contexts/PropContext';
 import { useBuilderStore } from '../../contexts/BuilderContext';
 import generateId from '../../utils/generateId';
@@ -17,11 +17,12 @@ const DraggableItemActions = () => {
   const onItemRemove = usePropStore(state => state.onItemRemove);
   const onItemAdd = usePropStore(state => state.onItemAdd);
 
-  const setActiveElement = useBuilderStore(state => state.setActiveElement);
+  const setActiveElements = useBuilderStore(state => state.setActiveElements);
+  const resetActiveElements = useBuilderStore(state => state.resetActiveElements);
   const setIsRightPanelOpen = useBuilderStore(state => state.setIsRightPanelOpen);
 
-  const activeElement = useActiveElement();
-  const item = activeElement[0]; // ACTIONS WORKS ONLY FOR ONE ITEM
+  const selectedElements = useSelectedElements();
+  const item = selectedElements[0]; // ACTIONS WORKS ONLY FOR ONE ITEM
 
   const { isLocked } = item;
 
@@ -29,14 +30,13 @@ const DraggableItemActions = () => {
     onAnEventTrigger(isLocked ? 'unlockReportItem' : 'lockReportItem', item.itemType);
     onItemChange({ id: item.id }, { isLocked: isLocked ? false : true });
     if (!isLocked) {
-      setActiveElement(item.id, false);
       setIsRightPanelOpen(false);
     }
   };
 
   const deleteItem = () => {
     setIsRightPanelOpen(false);
-    setActiveElement(null);
+    resetActiveElements();
     onItemRemove(item);
     onAnEventTrigger('removeItem', item.itemType);
   };
@@ -50,12 +50,11 @@ const DraggableItemActions = () => {
       top: item.top + 50,
     });
     onAnEventTrigger('duplicateItem', item.itemType);
-    setActiveElement(itemID);
+    setActiveElements(itemID, true);
     setIsRightPanelOpen(true);
   };
 
   const openSettings = () => {
-    setActiveElement(item.id);
     setIsRightPanelOpen(true);
   };
 

--- a/src/components/DraggableItem/DraggableItemLayer.js
+++ b/src/components/DraggableItem/DraggableItemLayer.js
@@ -5,7 +5,7 @@ import { getCoordinatesFromMatches, getCorrectDroppedOffsetValue, getMatchesForI
 import ItemPositioner from '../ItemPositioner';
 import { useBuilderStore } from '../../contexts/BuilderContext';
 import { usePropStore } from '../../contexts/PropContext';
-import { useActiveElement } from '../../utils/hooks';
+import { useSelectedElements } from '../../utils/hooks';
 
 const getDraggedItem = ({ defaultItem = {}, details }, item) => ({
   ...defaultItem,
@@ -99,12 +99,12 @@ const DraggableItemLayer = ({
     };
   }, [zoom]);
 
-  const activeItems = useActiveElement();
+  const selectedElements = useSelectedElements();
 
-  const hasActiveItems = activeItems !== null && activeItems.length > 0;
+  const hasActiveItems = selectedElements.length > 0;
 
   // for a element is added from the left panel
-  const activeElements = hasActiveItems ? activeItems : [referenceItem];
+  const activeElements = hasActiveItems ? selectedElements : [referenceItem];
 
   return activeElements.map(activeItem => {
     const coords = hasActiveItems ? {
@@ -116,7 +116,7 @@ const DraggableItemLayer = ({
 
     return (
       <ItemPositioner
-        key={item.id}
+        key={activeItem.id}
         classNames="reportItem isDraggingLayerElement"
         style={getItemStyle(coords, exactItem)}
       >

--- a/src/components/PageItemResizer.js
+++ b/src/components/PageItemResizer.js
@@ -48,11 +48,9 @@ const PageItemResizer = ({
 }) => {
   const zoom = useBuilderStore(state => state.zoom);
   const setIsRightPanelOpen = useBuilderStore(state => state.setIsRightPanelOpen);
-  const setActiveElement = useBuilderStore(state => state.setActiveElement);
-  const activeElement = useBuilderStore(state => state.activeElement);
+  const resetActiveElements = useBuilderStore(state => state.resetActiveElements);
+  const isMultipleItemSelected = useBuilderStore(state => state.activeElements.length > 1);
   const isTextEditorOpen = useBuilderStore(state => state.isTextEditorOpen);
-
-  const isMultipleItemSelected = activeElement !== null && activeElement.length > 1;
 
   const requestRef = useRef();
   const [lockAspectRatio, setLockAspectRatio] = useState(false);
@@ -112,7 +110,7 @@ const PageItemResizer = ({
       return;
     }
     setIsRightPanelOpen(false);
-    setActiveElement(null);
+    resetActiveElements();
   };
 
   const itemPositionerStyle = useMemo(() => ({

--- a/src/components/Panels/AllSlidesPanel/AllSlidesPanel.js
+++ b/src/components/Panels/AllSlidesPanel/AllSlidesPanel.js
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import classNames from 'classnames';
 import Panel from '../../Builder/Panel';
 import { useBuilderStore } from '../../../contexts/BuilderContext';
@@ -94,4 +94,4 @@ const AllSlidesPanel = () => {
   );
 };
 
-export default memo(AllSlidesPanel);
+export default AllSlidesPanel;

--- a/src/components/Panels/AllSlidesPanel/PageList.js
+++ b/src/components/Panels/AllSlidesPanel/PageList.js
@@ -140,12 +140,6 @@ const PageList = ({
 };
 
 PageList.propTypes = {
-  acceptedItems: PropTypes.shape({}),
-  layoutSettings: PropTypes.shape({
-    reportBackgroundColor: PropTypes.string,
-    reportLayoutHeight: PropTypes.string,
-    reportLayoutWidth: PropTypes.string,
-  }),
   onPageClick: PropTypes.func,
   onSortEnd: PropTypes.func,
   selectedPages: PropTypes.arrayOf(PropTypes.string),

--- a/src/components/Panels/LeftPanel/LeftPanel.js
+++ b/src/components/Panels/LeftPanel/LeftPanel.js
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import classNames from 'classnames';
 import Panel from '../../Builder/Panel';
 import { useBuilderStore } from '../../../contexts/BuilderContext';
@@ -23,4 +22,4 @@ const LeftPanel = () => {
   );
 };
 
-export default memo(LeftPanel);
+export default LeftPanel;

--- a/src/components/Panels/LeftPanel/LeftPanelOpener.js
+++ b/src/components/Panels/LeftPanel/LeftPanelOpener.js
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import { useBuilderStore } from '../../../contexts/BuilderContext';
 import * as icons from '../../../utils/icons';
 import { useTranslatedTexts } from '../../../utils/hooks';
@@ -6,11 +5,16 @@ import { useTranslatedTexts } from '../../../utils/hooks';
 const LeftPanelToggler = () => {
   const setIsLeftPanelOpen = useBuilderStore(state => state.setIsLeftPanelOpen);
   const { ADD_ELEMENT } = useTranslatedTexts();
+
+  const onOpenLeftPanel = () => {
+    setIsLeftPanelOpen(true);
+  };
+
   return (
     <>
       <button
         className="paneToggler addElementToggle"
-        onClick={() => { setIsLeftPanelOpen(true); }}
+        onClick={onOpenLeftPanel}
         title={ADD_ELEMENT}
         type="button"
       >
@@ -21,4 +25,4 @@ const LeftPanelToggler = () => {
   );
 };
 
-export default memo(LeftPanelToggler);
+export default LeftPanelToggler;

--- a/src/components/Panels/RightPanel/RightPanel.js
+++ b/src/components/Panels/RightPanel/RightPanel.js
@@ -30,7 +30,7 @@ const RightPanel = () => {
   const editedElement = useBuilderStore(state => state.editedElement);
   const isRightPanelOpen = useBuilderStore(state => state.isRightPanelOpen);
   const isSlidesPanelOpen = useBuilderStore(state => state.isSlidesPanelOpen);
-  const setActiveElement = useBuilderStore(state => state.setActiveElement);
+  const resetActiveElements = useBuilderStore(state => state.resetActiveElements);
   const setActiveTab = useBuilderStore(state => state.setActiveTab);
   const setIsRightPanelOpen = useBuilderStore(state => state.setIsRightPanelOpen);
 
@@ -87,7 +87,7 @@ const RightPanel = () => {
           ...pageItem,
           settings: pageItem.settings.map(setting => {
             if (setting.key === 'pageLayer') {
-              return { ...setting, setActiveElement, updater: onItemChange };
+              return { ...setting, updater: onItemChange };
             }
             return setting;
           }) || Page.settings,
@@ -104,7 +104,6 @@ const RightPanel = () => {
     onSettingChange,
     translatedTexts,
     pages,
-    setActiveElement,
   ]);
 
   const editedEl = useMemo(() => {
@@ -166,8 +165,8 @@ const RightPanel = () => {
       return;
     }
     setIsRightPanelOpen(false);
-    setActiveElement(null);
-  }, [editedElement, panelRef, setIsRightPanelOpen, setActiveElement]);
+    resetActiveElements();
+  }, [editedElement, setIsRightPanelOpen, resetActiveElements]);
 
   useEffect(() => {
     if (isRightPanelOpen) window.addEventListener('click', onClickOutsideForPanel, false);

--- a/src/components/Panels/RightPanel/RightPanelToggler.js
+++ b/src/components/Panels/RightPanel/RightPanelToggler.js
@@ -1,21 +1,22 @@
-import { memo } from 'react';
 import { useBuilderStore } from '../../../contexts/BuilderContext';
 import * as icons from '../../../utils/icons';
 import { useTranslatedTexts } from '../../../utils/hooks';
 
 const RightPanelToggler = () => {
-  const setActiveElement = useBuilderStore(state => state.setActiveElement);
+  const resetActiveElements = useBuilderStore(state => state.resetActiveElements);
   const setIsRightPanelOpen = useBuilderStore(state => state.setIsRightPanelOpen);
   const { LAYOUT_SETTINGS } = useTranslatedTexts();
+
+  const onOpenRightPanel = () => {
+    resetActiveElements();
+    setIsRightPanelOpen(true);
+  };
 
   return (
     <>
       <button
         className="paneToggler js-openRightPanel settingsToggle"
-        onClick={() => {
-          setActiveElement(null);
-          setIsRightPanelOpen(true);
-        }}
+        onClick={onOpenRightPanel}
         title={LAYOUT_SETTINGS}
         type="button"
       >
@@ -32,4 +33,4 @@ const RightPanelToggler = () => {
   );
 };
 
-export default memo(RightPanelToggler);
+export default RightPanelToggler;

--- a/src/components/Panels/SlidesPanel/SlidesPanel.js
+++ b/src/components/Panels/SlidesPanel/SlidesPanel.js
@@ -1,4 +1,4 @@
-import { memo, useCallback, useState } from 'react';
+import { useCallback, useState } from 'react';
 import classNames from 'classnames';
 import Panel from '../../Builder/Panel';
 import SortablePageList from './SortablePageList';
@@ -102,4 +102,4 @@ const SlidesPanel = () => {
   );
 };
 
-export default memo(SlidesPanel);
+export default SlidesPanel;

--- a/src/components/Panels/SlidesPanel/SlidesPanelToggler.js
+++ b/src/components/Panels/SlidesPanel/SlidesPanelToggler.js
@@ -4,18 +4,20 @@ import * as icons from '../../../utils/icons';
 import { useTranslatedTexts } from '../../../utils/hooks';
 
 const SlidesPanelToggler = ({ onClosePanel = () => {} }) => {
-  const setActiveElement = useBuilderStore(state => state.setActiveElement);
+  const resetActiveElements = useBuilderStore(state => state.resetActiveElements);
   const setIsSlidesPanelOpen = useBuilderStore(state => state.setIsSlidesPanelOpen);
   const { SLIDES } = useTranslatedTexts();
+
+  const onOpenSlidesPanel = () => {
+    resetActiveElements();
+    setIsSlidesPanelOpen(true);
+  };
 
   return (
     <>
       <button
         className="paneToggler settingsToggle"
-        onClick={() => {
-          setActiveElement(null);
-          setIsSlidesPanelOpen(true);
-        }}
+        onClick={onOpenSlidesPanel}
         title={SLIDES}
         type="button"
       >

--- a/src/components/ReportItemsWrapper.js
+++ b/src/components/ReportItemsWrapper.js
@@ -13,7 +13,7 @@ const ReportItemsWrapper = ({
   items,
 }) => {
   const acceptedItems = usePropStore(state => state.acceptedItems);
-  const activeElement = useBuilderStore(state => state.activeElement);
+  const activeElements = useBuilderStore(state => state.activeElements);
   const itemAccessor = usePropStore(state => state.itemAccessor);
   const onAnEventTrigger = usePropStore(state => state.onAnEventTrigger);
   const onItemChange = usePropStore(state => state.onItemChange);
@@ -38,8 +38,8 @@ const ReportItemsWrapper = ({
           >
             {ReportItem => (
               <ReportItem
-                isMultipleItemSelected={activeElement !== null && activeElement.length > 1}
-                isSelected={isSelectedItem(item.id, activeElement)}
+                isMultipleItemSelected={activeElements.length > 1}
+                isSelected={isSelectedItem(item.id, activeElements)}
                 item={mergedItem}
                 itemAccessor={itemAccessor}
                 onAnEventTrigger={onAnEventTrigger}

--- a/src/components/Settings/PageLayer/LayerItem.js
+++ b/src/components/Settings/PageLayer/LayerItem.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { capitalize, stripHTML } from '../../../utils/string';
 import * as icons from '../../../utils/icons';
 import { useTranslatedTexts } from '../../../utils/hooks';
+import { useBuilderStore } from '../../../contexts/BuilderContext';
 
 const DragHandle = () => (
   <span className="jfReportSelectOption-drag">
@@ -19,7 +20,6 @@ const LayerItem = ({
   item,
   onItemChange,
   optionKey,
-  setActiveElement,
 }) => {
   const {
     attributes,
@@ -30,6 +30,7 @@ const LayerItem = ({
     transition,
   } = useSortable({ id: itemId });
 
+  const setActiveElements = useBuilderStore(state => state.setActiveElements);
   const dragStyle = useMemo(() => ({
     opacity: isDragging ? 0.5 : 1,
     transform: CSS.Transform.toString(transform),
@@ -78,6 +79,10 @@ const LayerItem = ({
     PAGE_ELEMENT,
   ]);
 
+  const handleClick = () => {
+    setActiveElements(id, false);
+  };
+
   const content = useMemo(() => (
     <div className="jfReportSelectOption">
       <div className="jfReportSelectOption-icon">
@@ -95,7 +100,7 @@ const LayerItem = ({
       className={classNames('jfReportSelectOption', {
         isSelected: isVisib,
       })}
-      onClick={() => setActiveElement(id, false)}
+      onClick={handleClick}
       onKeyDown={() => {}}
       style={dragStyle}
       {...attributes}
@@ -144,7 +149,6 @@ LayerItem.propTypes = {
   }),
   onItemChange: PropTypes.func,
   optionKey: PropTypes.string,
-  setActiveElement: PropTypes.func,
 };
 
 export default memo(LayerItem);

--- a/src/components/Settings/PageLayer/PageLayer.js
+++ b/src/components/Settings/PageLayer/PageLayer.js
@@ -103,7 +103,6 @@ const PageLayer = ({
                   item={item}
                   onItemChange={config.updater}
                   optionKey={index}
-                  setActiveElement={config.setActiveElement}
                 />
               );
             })}
@@ -121,7 +120,6 @@ const PageLayer = ({
 
 PageLayer.propTypes = {
   config: PropTypes.shape({
-    setActiveElement: PropTypes.func,
     updater: PropTypes.func,
   }),
   item: PropTypes.shape({

--- a/src/components/TextEditor/CustomToolbar/CustomToolbarWrapper.js
+++ b/src/components/TextEditor/CustomToolbar/CustomToolbarWrapper.js
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import PropTypes from 'prop-types';
 import CustomToolbar from './CustomToolbar';
 
@@ -21,4 +20,4 @@ CustomToolbarWrapper.propTypes = {
   itemWidth: PropTypes.number,
 };
 
-export default memo(CustomToolbarWrapper);
+export default CustomToolbarWrapper;

--- a/src/contexts/BuilderContext.js
+++ b/src/contexts/BuilderContext.js
@@ -16,9 +16,9 @@ const builderStore = props => {
     isTextEditorOpen: props.isTextEditorOpen || false,
     lastScrollPosition: props.lastScrollPosition || 0,
     onRightPanelsToggled: props.onRightPanelsToggled || (() => {}),
-    resetActiveElements: () => {
+    resetActiveElements: props.resetActiveElements || (() => {
       set({ activeElements: [], editedElement: 'l_layout' });
-    },
+    }),
     setActiveElements: props.setActiveElements || ((itemID, edit = true, replace = true) => {
       const { activeElements } = get();
       set({

--- a/src/contexts/BuilderContext.js
+++ b/src/contexts/BuilderContext.js
@@ -4,7 +4,7 @@ import { createStore, useStore } from 'zustand';
 
 const builderStore = props => {
   return createStore((set, get) => ({
-    activeElement: props.activeElement || null,
+    activeElements: props.activeElement || [],
     activeTab: props.activeTab || { left: 0, right: 0 },
     contextMenuProps: props.contextMenuProps || false,
     editedElement: props.editedElement || 'l_layout',
@@ -16,20 +16,15 @@ const builderStore = props => {
     isTextEditorOpen: props.isTextEditorOpen || false,
     lastScrollPosition: props.lastScrollPosition || 0,
     onRightPanelsToggled: props.onRightPanelsToggled || (() => {}),
-    setActiveElement: props.setActiveElement || ((itemID, edit = true, multiple = false) => {
-      if (!multiple) {
-        const config = {
-          activeElement: itemID === null ? null : [itemID],
-        };
-        if (edit) {
-          const editedElement = !itemID ? 'l_layout' : `i_${itemID}`;
-          config.editedElement = editedElement;
-        }
-        set(config);
-      } else {
-        const { activeElement } = get();
-        set({ activeElement: activeElement === null ? [itemID] : [...activeElement, itemID] });
-      }
+    resetActiveElements: () => {
+      set({ activeElements: [] });
+    },
+    setActiveElements: props.setActiveElements || ((itemID, edit = true, replace = true) => {
+      const { activeElements } = get();
+      set({
+        activeElements: replace ? [itemID] : [...activeElements, itemID],
+        ...edit ? { editedElement: !itemID ? 'l_layout' : `i_${itemID}` } : {},
+      });
     }),
     setActiveTab: props.setActiveTab || ((panel, tabIndex) => {
       const { activeTab } = get();

--- a/src/contexts/BuilderContext.js
+++ b/src/contexts/BuilderContext.js
@@ -17,7 +17,7 @@ const builderStore = props => {
     lastScrollPosition: props.lastScrollPosition || 0,
     onRightPanelsToggled: props.onRightPanelsToggled || (() => {}),
     resetActiveElements: () => {
-      set({ activeElements: [] });
+      set({ activeElements: [], editedElement: 'l_layout' });
     },
     setActiveElements: props.setActiveElements || ((itemID, edit = true, replace = true) => {
       const { activeElements } = get();

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -30,20 +30,13 @@ export const getStyles = (left, top, isDragging) => {
 };
 
 export const isSelectedItem = (id, activeElements) => {
-  if (activeElements === null) return id === activeElements;
-  return activeElements.indexOf(id) !== -1;
+  return activeElements.includes(id);
 };
 
 export const findItemById = (itemID, pages) => {
   const page = pages.find(p => p.items.find(item => item.id === itemID));
   if (!page) return null;
   return page.items.find(item => item.id === itemID);
-};
-
-export const getSelectedItems = (selectedItemsIds, pages) => {
-  const page = pages.find(p => p.items.find(item => isSelectedItem(item.id, selectedItemsIds)));
-  if (!page) return null;
-  return page.items.filter(item => isSelectedItem(item.id, selectedItemsIds));
 };
 
 const traverse = (obj, condition) => condition.split('.').reduce((cur, key) => cur[key], obj);

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -195,14 +195,14 @@ export const usePageTransition = (style, currentPage) => {
   return finalStyle;
 };
 
-export const useActiveElement = () => {
+export const useSelectedElements = () => {
   const pages = usePropStore(state => state.pages);
-  const activeElement = useBuilderStore(state => state.activeElement);
+  const activeElements = useBuilderStore(state => state.activeElements);
   const acceptedItems = usePropStore(state => state.acceptedItems);
 
   return useMemo(() => {
-    if (activeElement === null || activeElement.length === 0) return [];
-    const items = activeElement.map(itemID => {
+    if (activeElements.length === 0) return [];
+    const items = activeElements.map(itemID => {
       let foundItem = [];
       pages.forEach(page => {
         const item = page.items.find(el => el.id === itemID);
@@ -214,5 +214,5 @@ export const useActiveElement = () => {
       return { ...defItem, ...foundItem };
     });
     return items;
-  }, [pages, activeElement, acceptedItems]);
+  }, [pages, activeElements, acceptedItems]);
 };


### PR DESCRIPTION
Updates the builder store and related components to manage multiple selected elements. This change introduces the ability to select and manipulate multiple items simultaneously, enhancing the user experience and providing more flexibility in page design.

Replaces single `activeElement` with `activeElements` array in the store. Updates component logic to use `activeElements` for determining selection state. Adds `resetActiveElements` action to clear selected items. Updates DraggableItem component to use the new multi-select logic.