### PR TITLE
refactor: refactors guides and matches logic to BuilderContext

### DIFF
--- a/src/components/Builder/DraggableLayer.js
+++ b/src/components/Builder/DraggableLayer.js
@@ -3,7 +3,6 @@ import { useDragLayer } from 'react-dnd';
 import DraggableItemLayer from '../DraggableItem/DraggableItemLayer';
 
 const DraggableLayer = ({
-  guides = {},
   pageRefs = {},
 }) => {
   const collectedProps = useDragLayer(monitor => ({
@@ -21,14 +20,12 @@ const DraggableLayer = ({
   return (
     <DraggableItemLayer
       collectedProps={collectedProps}
-      guides={guides}
       pageRefs={pageRefs}
     />
   );
 };
 
 DraggableLayer.propTypes = {
-  guides: PropTypes.shape({}),
   pageRefs: PropTypes.shape({}),
 };
 

--- a/src/components/Builder/Scene.js
+++ b/src/components/Builder/Scene.js
@@ -4,7 +4,6 @@ import {
   Fragment,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -44,6 +43,7 @@ const Scene = () => {
   const resetActiveElements = useBuilderStore(state => state.resetActiveElements);
   const setActiveElementsSelection = useBuilderStore(state => state.setActiveElementsSelection);
   const setContextMenuProps = useBuilderStore(state => state.setContextMenuProps);
+  const setGuides = useBuilderStore(state => state.setGuides);
   const setIsRightPanelOpen = useBuilderStore(state => state.setIsRightPanelOpen);
   const zoom = useBuilderStore(state => state.zoom);
 
@@ -80,8 +80,8 @@ const Scene = () => {
   /* Calculate snap guides */
   const keyDownCount = useRef(null);
 
-  const guides = useMemo(() => {
-    return pages.reduce((acc, page) => {
+  useEffect(() => {
+    setGuides(pages.reduce((acc, page) => {
       const _pageGuides = {};
       const pageRef = refs.current[page.id];
       if (pageRef && pageRef.current) {
@@ -104,8 +104,8 @@ const Scene = () => {
       }
       acc[page.id] = _pageGuides;
       return acc;
-    }, {});
-  }, [pages, zoom]);
+    }, {}));
+  }, [pages, zoom, setGuides]);
 
   useEffect(() => {
     if (viewPortRef.current) {
@@ -422,7 +422,6 @@ const Scene = () => {
       className={classNames.mainWrapper}
     >
       <DraggableLayer
-        guides={guides}
         pageRefs={refs.current}
       />
       <div
@@ -453,7 +452,6 @@ const Scene = () => {
                 style={{ ...pageStyles.current, position: 'relative' }}
               >
                 <Page
-                  guides={guides}
                   items={page.items}
                   page={page}
                   pageIndex={index}

--- a/src/components/DraggableItem/DraggableItemLayer.js
+++ b/src/components/DraggableItem/DraggableItemLayer.js
@@ -16,7 +16,6 @@ const getDraggedItem = ({ defaultItem = {}, details }, item) => ({
 
 const DraggableItemLayer = ({
   collectedProps = {},
-  guides = {},
   pageRefs = {},
 }) => {
   const {
@@ -26,6 +25,7 @@ const DraggableItemLayer = ({
     item,
   } = collectedProps;
   const zoom = useBuilderStore(state => state.zoom);
+  const guides = useBuilderStore(state => state.guides);
 
   const acceptedItems = usePropStore(state => state.acceptedItems);
   const itemAccessor = usePropStore(state => state.itemAccessor);
@@ -149,7 +149,6 @@ DraggableItemLayer.propTypes = {
     item: PropTypes.shape({}),
     itemType: PropTypes.string,
   }),
-  guides: PropTypes.shape({}),
   pageRefs: PropTypes.shape({}),
 };
 

--- a/src/components/ReportItemsWrapper.js
+++ b/src/components/ReportItemsWrapper.js
@@ -8,8 +8,6 @@ import { isSelectedItem } from '../utils/functions';
 import { usePropStore } from '../contexts/PropContext';
 
 const ReportItemsWrapper = ({
-  getIntersectionsFromMatches,
-  handleMatches,
   items,
 }) => {
   const acceptedItems = usePropStore(state => state.acceptedItems);
@@ -29,8 +27,6 @@ const ReportItemsWrapper = ({
       return (
         <DraggableItem
           key={item.id}
-          getIntersectionsFromMatches={getIntersectionsFromMatches}
-          handleMatches={handleMatches}
           item={item}
         >
           <ReportItemRenderer
@@ -53,8 +49,6 @@ const ReportItemsWrapper = ({
 };
 
 ReportItemsWrapper.propTypes = {
-  getIntersectionsFromMatches: PropTypes.func,
-  handleMatches: PropTypes.func,
   items: PropTypes.arrayOf(
     PropTypes.shape({}),
   ),

--- a/src/contexts/BuilderContext.js
+++ b/src/contexts/BuilderContext.js
@@ -8,6 +8,8 @@ const builderStore = props => {
     activeTab: props.activeTab || { left: 0, right: 0 },
     contextMenuProps: props.contextMenuProps || false,
     editedElement: props.editedElement || 'l_layout',
+    guides: {},
+    matches: {},
     isAllSlidesPanelOpen: props.isAllSlidesPanelOpen || false,
     isLeftPanelOpen: props.isLeftPanelOpen || false,
     isResize: false,
@@ -47,6 +49,12 @@ const builderStore = props => {
     },
     setEditedElement: id => {
       set({ editedElement: id });
+    },
+    setGuides: guides => {
+      set({ guides });
+    },
+    setMatches: matches => {
+      set({ matches });
     },
     setIsAllSlidesPanelOpen: status => {
       set({ isAllSlidesPanelOpen: status });

--- a/src/contexts/BuilderContext.js
+++ b/src/contexts/BuilderContext.js
@@ -9,7 +9,6 @@ const builderStore = props => {
     contextMenuProps: props.contextMenuProps || false,
     editedElement: props.editedElement || 'l_layout',
     guides: {},
-    matches: {},
     isAllSlidesPanelOpen: props.isAllSlidesPanelOpen || false,
     isLeftPanelOpen: props.isLeftPanelOpen || false,
     isResize: false,
@@ -17,6 +16,7 @@ const builderStore = props => {
     isSlidesPanelOpen: props.isSlidesPanelOpen || false,
     isTextEditorOpen: props.isTextEditorOpen || false,
     lastScrollPosition: props.lastScrollPosition || 0,
+    matches: {},
     onRightPanelsToggled: props.onRightPanelsToggled || (() => {}),
     resetActiveElements: props.resetActiveElements || (() => {
       set({ activeElements: [], editedElement: 'l_layout' });
@@ -53,9 +53,6 @@ const builderStore = props => {
     setGuides: guides => {
       set({ guides });
     },
-    setMatches: matches => {
-      set({ matches });
-    },
     setIsAllSlidesPanelOpen: status => {
       set({ isAllSlidesPanelOpen: status });
     },
@@ -89,6 +86,9 @@ const builderStore = props => {
     }),
     setIsTextEditorOpen: status => {
       set({ isTextEditorOpen: status });
+    },
+    setMatches: matches => {
+      set({ matches });
     },
     setZoom: (zoom, layoutWidth) => {
       set({ zoom });

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -101,19 +101,41 @@ export const getTabsWithElements = leftPanelConfig => {
   }, {});
 };
 
-export const calculateGuidePositions = (dimensions, axis, zoom = 1) => {
+export const calculateGuidePositions = (dimensions, axis, zoom = 1, direction = null) => {
   const isItem = dimensions && dimensions.id;
+
   if (axis === 'x') {
     const start = dimensions.left;
     const middle = dimensions.left + parseInt(dimensions.width / 2, 10);
     const end = dimensions.left + dimensions.width;
-    if (isItem) return [start, middle, end].map(p => p * zoom);
+
+    if (isItem) {
+      const result = [start, middle, end].map(p => p * zoom);
+      if (direction) {
+        if (direction === 'bottom') return [];
+        if (direction === 'top') return [];
+        if (/left/i.test(direction)) return [result[0]];
+        if (/right/i.test(direction)) return [result[2]];
+      }
+      return result;
+    }
     return [start, middle, end];
   }
+
   const start = dimensions.top;
   const middle = dimensions.top + parseInt(dimensions.height / 2, 10);
   const end = dimensions.top + dimensions.height;
-  if (isItem) return [start, middle, end].map(p => p * zoom);
+
+  if (isItem) {
+    const result = [start, middle, end].map(p => p * zoom);
+    if (direction) {
+      if (direction === 'left') return [];
+      if (direction === 'right') return [];
+      if (/top/i.test(direction)) return [result[0]];
+      if (/bottom/i.test(direction)) return [result[2]];
+    }
+    return result;
+  }
   return [start, middle, end];
 };
 
@@ -198,14 +220,14 @@ export const proximityListener = (active, allGuides) => {
   return allMatchedGuides;
 };
 
-export const getMatchesForItem = (item, guides, zoom) => {
+export const getMatchesForItem = (item, guides, zoom, direction = null) => {
   const pageGuides = guides[item.pageID];
   const _guides = {
     ...pageGuides,
     [item.id]: {
       ...pageGuides[item.id],
-      x: calculateGuidePositions(item, 'x', zoom),
-      y: calculateGuidePositions(item, 'y', zoom),
+      x: calculateGuidePositions(item, 'x', zoom, direction),
+      y: calculateGuidePositions(item, 'y', zoom, direction),
     },
   };
   return proximityListener(item.id, _guides);


### PR DESCRIPTION
Moves the guides and matches state management to the BuilderContext. This simplifies prop drilling and centralizes the logic for calculating and managing alignment guides during item drag and resize operations. This change also fixes a bug where alignment guides were not being cleared when an item was dropped. The alignment guides are now only shown for the page of the selected element when resizing.