### PR TITLE
fix: rounds position values before service calls

### DIFF
--- a/src/components/DraggableItem/DraggableItem.js
+++ b/src/components/DraggableItem/DraggableItem.js
@@ -7,7 +7,7 @@ import { getEmptyImage } from 'react-dnd-html5-backend';
 import ItemPositioner from '../ItemPositioner';
 import { DRAGGABLE_ITEM_TYPE } from '../../constants/itemTypes';
 import {
-  getStyles, getPosition, isSelectedItem, getMatchesForItem,
+  getStyles, getPosition, isSelectedItem, getMatchesForItem, roundPositionValues,
 } from '../../utils/functions';
 import PageItemResizer from '../PageItemResizer';
 import ErrorBoundary from '../ErrorBoundary';
@@ -146,12 +146,12 @@ const DraggableItem = ({
   const onResizeStop = () => {
     setIsResize(false);
     setMatches({});
-    onItemResize(item, {
+    onItemResize(item, roundPositionValues({
       height: stateHeight,
       left: stateLeft,
       top: stateTop,
       width: stateWidth,
-    });
+    }));
   };
 
   const onResize = (deltaWidth, deltaHeight, direction) => {

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -1,6 +1,25 @@
 /* global Image */
 import objectDiff from './object-diff';
 
+/**
+ * Rounds position/dimension values to integers before sending to service
+ * This prevents decimal values from being sent when zoom is not 1
+ * Should only be used at the final step before service calls
+ */
+export const roundPositionValues = ({
+  height,
+  left,
+  top,
+  width,
+  ...rest
+}) => ({
+  ...rest,
+  ...(height !== undefined && { height: Math.round(height) }),
+  ...(left !== undefined && { left: Math.round(left) }),
+  ...(top !== undefined && { top: Math.round(top) }),
+  ...(width !== undefined && { width: Math.round(width) }),
+});
+
 export const getCorrectDroppedOffsetValue = (finalOffset, initialOffset, dropTargetPosition, zoom = 1) => {
   const { x: finalX, y: finalY } = finalOffset;
   const { x: initialX, y: initialY } = initialOffset;
@@ -259,11 +278,6 @@ export const getCoordinatesFromMatches = (item, matches, zoom = 1) => {
     left: newActiveBoxLeft,
     top: newActiveBoxTop,
   };
-};
-
-export const getCorrectDroppedOffsetValueBySnap = (item, guides, zoom) => {
-  const matches = getMatchesForItem(item, guides, zoom);
-  return getCoordinatesFromMatches(item, matches, zoom);
 };
 
 export const getPosition = e => {


### PR DESCRIPTION
Ensures that position and dimension values are rounded to integers before being sent to the backend service. This prevents issues caused by decimal values, especially when the zoom level is not 1.