### PR TITLE
feat: passes selected items to a callback function

### DIFF
--- a/src/components/Builder/Builder.js
+++ b/src/components/Builder/Builder.js
@@ -72,6 +72,8 @@ Builder.propTypes = {
    * not the panel is toggled open.
    */
   onRightPanelsToggled: PropTypes.func,
+  /** Function called upon selecting items */
+  onSelectedItemsChange: PropTypes.func,
   /** Function called upon editing a general report setting */
   onSettingChange: PropTypes.func,
   /** Array of pages with their settings and items */

--- a/src/components/Builder/BuilderWrapper.js
+++ b/src/components/Builder/BuilderWrapper.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ReportWrapper from '../ReportWrapper';
 import { usePropStore } from '../../contexts/PropContext';
 import { useBuilderStore } from '../../contexts/BuilderContext';
-import { useFitZoom } from '../../utils/hooks';
+import { useFitZoom, useSelectedElements } from '../../utils/hooks';
 
 const BuilderWrapper = ({ children }) => {
   const decidedWhichPanelToOpen = useRef(false);
@@ -13,6 +13,13 @@ const BuilderWrapper = ({ children }) => {
   const isSlidesPanelOpen = useBuilderStore(state => state.isSlidesPanelOpen);
   const setIsLeftPanelOpen = useBuilderStore(state => state.setIsLeftPanelOpen);
   const setIsSlidesPanelOpen = useBuilderStore(state => state.setIsSlidesPanelOpen);
+  const onSelectedItemsChange = usePropStore(state => state.onSelectedItemsChange);
+
+  const selectedItems = useSelectedElements();
+
+  useEffect(() => {
+    onSelectedItemsChange(selectedItems);
+  }, [selectedItems, onSelectedItemsChange]);
 
   useFitZoom();
 

--- a/src/contexts/PropContext.js
+++ b/src/contexts/PropContext.js
@@ -26,6 +26,7 @@ const propStore = props => {
     onPageDuplicate: props.onPageDuplicate || fn,
     onPageOrdersChange: props.onPageOrdersChange || fn,
     onPageRemove: props.onPageRemove || fn,
+    onSelectedItemsChange: props.onSelectedItemsChange || fn,
     onSettingChange: props.onSettingChange || fn,
     pages: props.pages || [],
     setAcceptedItems: acceptedItems => { set({ acceptedItems }); },


### PR DESCRIPTION
This commit introduces a mechanism to notify the application when the user selects items within the builder.

It adds a new `onSelectedItemsChange` prop to the Builder component and utilizes the `useSelectedElements` hook to track selected items. Whenever the selected items change, the `onSelectedItemsChange` callback is invoked, allowing the application to respond to user selections.