### PR TITLE
fix: renames and memoizes selected items handler

### DIFF
--- a/src/components/Builder/Builder.js
+++ b/src/components/Builder/Builder.js
@@ -73,7 +73,7 @@ Builder.propTypes = {
    */
   onRightPanelsToggled: PropTypes.func,
   /** Function called upon selecting items */
-  onSelectedItemsChange: PropTypes.func,
+  onSelectedItemsChanged: PropTypes.func,
   /** Function called upon editing a general report setting */
   onSettingChange: PropTypes.func,
   /** Array of pages with their settings and items */

--- a/src/components/Builder/BuilderWrapper.js
+++ b/src/components/Builder/BuilderWrapper.js
@@ -1,9 +1,10 @@
 import { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+import isEqual from 'lodash.isequal';
 import ReportWrapper from '../ReportWrapper';
 import { usePropStore } from '../../contexts/PropContext';
 import { useBuilderStore } from '../../contexts/BuilderContext';
-import { useFitZoom, useSelectedElements } from '../../utils/hooks';
+import { useFitZoom, usePrevious, useSelectedElements } from '../../utils/hooks';
 
 const BuilderWrapper = ({ children }) => {
   const decidedWhichPanelToOpen = useRef(false);
@@ -13,13 +14,19 @@ const BuilderWrapper = ({ children }) => {
   const isSlidesPanelOpen = useBuilderStore(state => state.isSlidesPanelOpen);
   const setIsLeftPanelOpen = useBuilderStore(state => state.setIsLeftPanelOpen);
   const setIsSlidesPanelOpen = useBuilderStore(state => state.setIsSlidesPanelOpen);
-  const onSelectedItemsChange = usePropStore(state => state.onSelectedItemsChange);
-
+  const onSelectedItemsChanged = usePropStore(state => state.onSelectedItemsChanged);
   const selectedItems = useSelectedElements();
+  const prevSelectedItems = usePrevious(selectedItems);
 
   useEffect(() => {
-    onSelectedItemsChange(selectedItems);
-  }, [selectedItems, onSelectedItemsChange]);
+    if (prevSelectedItems && !isEqual(prevSelectedItems, selectedItems)) {
+      onSelectedItemsChanged(selectedItems);
+    }
+  }, [
+    selectedItems,
+    onSelectedItemsChanged,
+    prevSelectedItems,
+  ]);
 
   useFitZoom();
 

--- a/src/components/Panels/LeftPanel/LeftPanelCloser.js
+++ b/src/components/Panels/LeftPanel/LeftPanelCloser.js
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import { useBuilderStore } from '../../../contexts/BuilderContext';
 import * as icons from '../../../utils/icons';
 
@@ -17,4 +16,4 @@ const LeftPanelToggler = () => {
   );
 };
 
-export default memo(LeftPanelToggler);
+export default LeftPanelToggler;

--- a/src/components/Panels/RightPanel/RightPanel.js
+++ b/src/components/Panels/RightPanel/RightPanel.js
@@ -1,5 +1,4 @@
 import {
-  memo,
   useCallback,
   useEffect,
   useMemo,
@@ -204,4 +203,4 @@ const RightPanel = () => {
   );
 };
 
-export default memo(RightPanel);
+export default RightPanel;

--- a/src/contexts/PropContext.js
+++ b/src/contexts/PropContext.js
@@ -2,6 +2,7 @@ import {
   createContext, useContext, useEffect, useRef,
 } from 'react';
 import PropTypes from 'prop-types';
+import isEqual from 'lodash.isequal';
 import { createStore, useStore } from 'zustand';
 
 const fn = () => {};
@@ -26,7 +27,7 @@ const propStore = props => {
     onPageDuplicate: props.onPageDuplicate || fn,
     onPageOrdersChange: props.onPageOrdersChange || fn,
     onPageRemove: props.onPageRemove || fn,
-    onSelectedItemsChange: props.onSelectedItemsChange || fn,
+    onSelectedItemsChanged: props.onSelectedItemsChanged || fn,
     onSettingChange: props.onSettingChange || fn,
     pages: props.pages || [],
     setAcceptedItems: acceptedItems => { set({ acceptedItems }); },
@@ -54,10 +55,9 @@ export const PropProvider = ({ children, ...props }) => {
   } = props;
 
   useEffect(() => {
-    const { setPages } = storeRef.current.getState();
-    if (pages) {
-      setPages(pages);
-    }
+    const state = storeRef.current.getState();
+    if (!pages || isEqual(state.pages, pages)) return;
+    state.setPages(pages);
   }, [pages]);
 
   useEffect(() => {
@@ -66,17 +66,15 @@ export const PropProvider = ({ children, ...props }) => {
   }, [itemAccessor]);
 
   useEffect(() => {
-    const { setAcceptedItems } = storeRef.current.getState();
-    if (acceptedItems) {
-      setAcceptedItems(acceptedItems);
-    }
+    const state = storeRef.current.getState();
+    if (!acceptedItems || isEqual(state.acceptedItems, acceptedItems)) return;
+    state.setAcceptedItems(acceptedItems);
   }, [acceptedItems]);
 
   useEffect(() => {
-    const { setSettings } = storeRef.current.getState();
-    if (settings) {
-      setSettings(settings);
-    }
+    const state = storeRef.current.getState();
+    if (!settings || isEqual(state.settings, settings)) return;
+    state.setSettings(settings);
   }, [settings]);
 
   return (


### PR DESCRIPTION
Renames `onSelectedItemsChange` to `onSelectedItemsChanged` for clarity and consistency.

Memoizes the `onSelectedItemsChanged` function call to prevent unnecessary re-renders, improving performance. Also removes unnecessary memo wrappers from functional components.