### PR TITLE
feat: adds callback for page visibility changes

### DIFF
--- a/src/components/Builder/Builder.js
+++ b/src/components/Builder/Builder.js
@@ -67,6 +67,8 @@ Builder.propTypes = {
   onPageOrdersChange: PropTypes.func,
   /** Function called upon removing a page */
   onPageRemove: PropTypes.func,
+  /** Function called upon page visibility changed */
+  onPageVisibilityChanged: PropTypes.func,
   /** Function called when the slides or the right panel is
    * toggled takes a boolean value to indicate whether or
    * not the panel is toggled open.

--- a/src/components/Panels/SlidesPanel/ListWrapper.js
+++ b/src/components/Panels/SlidesPanel/ListWrapper.js
@@ -12,12 +12,12 @@ const ListWrapper = ({
   onSortEnd = () => {},
   pageGetter = () => {},
 }) => {
-  const pages = usePropStore(state => state.pages);
-  const pageCount = useMemo(() => pages.length, [pages]);
+  const pageCount = usePropStore(state => state.pages.length);
   const onPageAdd = usePropStore(state => state.onPageAdd);
   const onPageDuplicate = usePropStore(state => state.onPageDuplicate);
   const onPageRemove = usePropStore(state => state.onPageRemove);
   const reportSettings = usePropStore(state => state.settings);
+  const onPageVisibilityChanged = usePropStore(state => state.onPageVisibilityChanged);
 
   const listRef = useRef(null);
   const [selectedPageIndex, setSelectedPageIndex] = useState(-1);
@@ -52,7 +52,7 @@ const ListWrapper = ({
     }
   }, []);
 
-  usePageVisibility(index => {
+  const handlePageVisibility = useCallback(index => {
     if (index && !Number.isNaN(index)) {
       if (listRef.current?.scrollToIndex) {
         listRef.current.scrollToIndex(index, 'center');
@@ -67,9 +67,12 @@ const ListWrapper = ({
         .querySelector(`.thumbnailWrapper[data-order="${index}"]`);
       if (nextSelectedThumbnail) {
         nextSelectedThumbnail.classList.add('isSelected');
+        onPageVisibilityChanged(index);
       }
     }
-  }, pageCount, selectedPageIndex);
+  }, [onPageVisibilityChanged]);
+
+  usePageVisibility(handlePageVisibility, pageCount, selectedPageIndex);
 
   // TODO: could be better than now. scrollend listener is a choice for some cases
   const resetSelectedPageIndex = useCallback(() => {

--- a/src/contexts/PropContext.js
+++ b/src/contexts/PropContext.js
@@ -27,6 +27,7 @@ const propStore = props => {
     onPageDuplicate: props.onPageDuplicate || fn,
     onPageOrdersChange: props.onPageOrdersChange || fn,
     onPageRemove: props.onPageRemove || fn,
+    onPageVisibilityChanged: props.onPageVisibilityChanged || fn,
     onSelectedItemsChanged: props.onSelectedItemsChanged || fn,
     onSettingChange: props.onSettingChange || fn,
     pages: props.pages || [],

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -88,6 +88,7 @@ export const useFitZoom = () => {
 
 export const usePageVisibility = (callback, pageCount, selectedPageIndex) => {
   const ratio = useRef({});
+  const prevVisiblePageIndex = useRef(-1);
   const pageRefs = useRef([]);
   const observer = useMemo(() => new window.IntersectionObserver(entries => {
     entries.forEach(entry => {
@@ -98,16 +99,20 @@ export const usePageVisibility = (callback, pageCount, selectedPageIndex) => {
         delete ratio.current[order];
       }
     });
-    callback(parseInt(
+    const visiblePageIndex = parseInt(
       Object.keys(ratio.current)
         .find(key => ratio.current[key] === Math.max(...Object.values(ratio.current))),
       10,
-    ));
+    );
+    if (visiblePageIndex !== prevVisiblePageIndex.current) {
+      prevVisiblePageIndex.current = visiblePageIndex;
+      callback(visiblePageIndex);
+    }
   },
   {
     delay: 100,
     root: document.querySelector('.jfReport-viewport'),
-    threshold: [0, 0.5, 1],
+    threshold: [0, 0.25, 0.5, 0.75, 1],
   }), [callback]);
 
   useEffect(() => {


### PR DESCRIPTION
Enables the ability to trigger a callback when a page becomes visible in the viewport.

This allows for actions such as lazy loading of content or triggering animations when a page is in view.

Updates the visibility observer to only fire the callback when the most visible page changes.