### PR TITLE
fix: add missing PropTypes to components

### DIFF
--- a/src/__tests__/unit-tests/utils/functions.spec.js
+++ b/src/__tests__/unit-tests/utils/functions.spec.js
@@ -1,0 +1,540 @@
+import {
+  roundPositionValues,
+  getCorrectDroppedOffsetValue,
+  getStyles,
+  isSelectedItem,
+  findItemById,
+  moveItemInArrayFromIndexToIndex,
+  findItemsOnPage,
+  collisionCheck,
+  getFileName,
+  arrayMove,
+  normalizeHexColor,
+  isValidHexColor,
+  isItemInSelectionBox,
+  getItemsInSelectionBox,
+  getDimensions,
+  calculateGuidePositions,
+  getTabsWithElements,
+  emptyFunction,
+} from '../../../utils/functions';
+
+describe('utils/functions', () => {
+  describe('roundPositionValues', () => {
+    it('should round height, left, top, width to integers', () => {
+      const input = {
+        height: 100.7,
+        left: 50.3,
+        top: 25.9,
+        width: 200.1,
+      };
+      const result = roundPositionValues(input);
+      expect(result).toEqual({
+        height: 101,
+        left: 50,
+        top: 26,
+        width: 200,
+      });
+    });
+
+    it('should preserve other properties', () => {
+      const input = {
+        height: 100.5,
+        id: 'test-id',
+        left: 50.5,
+        name: 'test',
+      };
+      const result = roundPositionValues(input);
+      expect(result.id).toBe('test-id');
+      expect(result.name).toBe('test');
+    });
+
+    it('should handle undefined values', () => {
+      const input = { id: 'test' };
+      const result = roundPositionValues(input);
+      expect(result).toEqual({ id: 'test' });
+    });
+
+    it('should handle zero values', () => {
+      const input = {
+        height: 0,
+        left: 0,
+        top: 0,
+        width: 0,
+      };
+      const result = roundPositionValues(input);
+      expect(result).toEqual({
+        height: 0,
+        left: 0,
+        top: 0,
+        width: 0,
+      });
+    });
+  });
+
+  describe('getCorrectDroppedOffsetValue', () => {
+    it('should calculate correct position when moving right and down', () => {
+      const finalOffset = { x: 200, y: 200 };
+      const initialOffset = { x: 100, y: 100 };
+      const dropTargetPosition = { left: 50, top: 50 };
+
+      const result = getCorrectDroppedOffsetValue(
+        finalOffset,
+        initialOffset,
+        dropTargetPosition,
+      );
+
+      expect(result.left).toBe(150);
+      expect(result.top).toBe(150);
+    });
+
+    it('should calculate correct position when moving left and up', () => {
+      const finalOffset = { x: 50, y: 50 };
+      const initialOffset = { x: 100, y: 100 };
+      const dropTargetPosition = { left: 25, top: 25 };
+
+      const result = getCorrectDroppedOffsetValue(
+        finalOffset,
+        initialOffset,
+        dropTargetPosition,
+      );
+
+      expect(result.left).toBe(25);
+      expect(result.top).toBe(25);
+    });
+
+    it('should apply zoom factor', () => {
+      const finalOffset = { x: 200, y: 200 };
+      const initialOffset = { x: 100, y: 100 };
+      const dropTargetPosition = { left: 0, top: 0 };
+      const zoom = 2;
+
+      const result = getCorrectDroppedOffsetValue(
+        finalOffset,
+        initialOffset,
+        dropTargetPosition,
+        zoom,
+      );
+
+      expect(result.left).toBe(100);
+      expect(result.top).toBe(100);
+    });
+  });
+
+  describe('getStyles', () => {
+    it('should return correct styles when not dragging', () => {
+      const result = getStyles(100, 200, false);
+      expect(result).toEqual({
+        height: '',
+        left: 100,
+        opacity: 1,
+        position: 'absolute',
+        top: 200,
+      });
+    });
+
+    it('should return hidden styles when dragging', () => {
+      const result = getStyles(100, 200, true);
+      expect(result).toEqual({
+        height: 0,
+        left: 100,
+        opacity: 0,
+        position: 'absolute',
+        top: 200,
+      });
+    });
+  });
+
+  describe('isSelectedItem', () => {
+    it('should return true if id is in activeElements', () => {
+      const activeElements = ['item1', 'item2', 'item3'];
+      expect(isSelectedItem('item2', activeElements)).toBe(true);
+    });
+
+    it('should return false if id is not in activeElements', () => {
+      const activeElements = ['item1', 'item2', 'item3'];
+      expect(isSelectedItem('item4', activeElements)).toBe(false);
+    });
+
+    it('should return false for empty array', () => {
+      expect(isSelectedItem('item1', [])).toBe(false);
+    });
+  });
+
+  describe('findItemById', () => {
+    const pages = [
+      {
+        id: 'page1',
+        items: [
+          { id: 'item1', name: 'Item 1' },
+          { id: 'item2', name: 'Item 2' },
+        ],
+      },
+      {
+        id: 'page2',
+        items: [
+          { id: 'item3', name: 'Item 3' },
+        ],
+      },
+    ];
+
+    it('should find item on first page', () => {
+      const result = findItemById('item1', pages);
+      expect(result).toEqual({ id: 'item1', name: 'Item 1' });
+    });
+
+    it('should find item on second page', () => {
+      const result = findItemById('item3', pages);
+      expect(result).toEqual({ id: 'item3', name: 'Item 3' });
+    });
+
+    it('should return null if item not found', () => {
+      const result = findItemById('nonexistent', pages);
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty pages', () => {
+      const result = findItemById('item1', []);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('moveItemInArrayFromIndexToIndex', () => {
+    it('should move item forward in array', () => {
+      const array = ['a', 'b', 'c', 'd', 'e'];
+      const result = moveItemInArrayFromIndexToIndex(array, 1, 3);
+      expect(result).toEqual(['a', 'c', 'd', 'b', 'e']);
+    });
+
+    it('should move item backward in array', () => {
+      const array = ['a', 'b', 'c', 'd', 'e'];
+      const result = moveItemInArrayFromIndexToIndex(array, 3, 1);
+      expect(result).toEqual(['a', 'd', 'b', 'c', 'e']);
+    });
+
+    it('should return same array if fromIndex equals toIndex', () => {
+      const array = ['a', 'b', 'c'];
+      const result = moveItemInArrayFromIndexToIndex(array, 1, 1);
+      expect(result).toBe(array);
+    });
+
+    it('should not mutate original array', () => {
+      const array = ['a', 'b', 'c', 'd'];
+      moveItemInArrayFromIndexToIndex(array, 0, 3);
+      expect(array).toEqual(['a', 'b', 'c', 'd']);
+    });
+  });
+
+  describe('findItemsOnPage', () => {
+    const pages = [
+      {
+        id: 'page1',
+        items: [{ id: 'item1' }, { id: 'item2' }],
+      },
+      {
+        id: 'page2',
+        items: [{ id: 'item3' }],
+      },
+      {
+        id: 'page3',
+      },
+    ];
+
+    it('should return items for existing page', () => {
+      const result = findItemsOnPage('page1', pages);
+      expect(result).toEqual([{ id: 'item1' }, { id: 'item2' }]);
+    });
+
+    it('should return empty array for page without items', () => {
+      const result = findItemsOnPage('page3', pages);
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array for nonexistent page', () => {
+      const result = findItemsOnPage('nonexistent', pages);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('collisionCheck', () => {
+    const items = [
+      {
+        height: 100, left: 0, top: 0, width: 100,
+      },
+      {
+        height: 100, left: 50, top: 50, width: 100,
+      },
+      {
+        height: 100, left: 200, top: 200, width: 100,
+      },
+    ];
+
+    it('should detect collision when items overlap', () => {
+      const item = {
+        height: 100, left: 50, top: 50, width: 100,
+      };
+      const result = collisionCheck(item, items, 0, 1);
+      // Returns index of first colliding item found
+      expect(result).toBe(1);
+    });
+
+    it('should return null when no collision', () => {
+      const item = {
+        height: 50, left: 500, top: 500, width: 50,
+      };
+      const result = collisionCheck(item, items, 0, 1);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getFileName', () => {
+    it('should extract filename from URL', () => {
+      const url = 'https://example.com/path/to/image.png';
+      expect(getFileName(url)).toBe('image.png');
+    });
+
+    it('should handle URL with query parameters', () => {
+      const url = 'https://example.com/file.pdf?version=1&token=abc';
+      expect(getFileName(url)).toBe('file.pdf');
+    });
+
+    it('should handle empty string', () => {
+      expect(getFileName('')).toBe('');
+    });
+
+    it('should handle undefined', () => {
+      expect(getFileName()).toBe('');
+    });
+
+    it('should handle simple filename', () => {
+      expect(getFileName('document.txt')).toBe('document.txt');
+    });
+  });
+
+  describe('arrayMove', () => {
+    it('should move element from one position to another', () => {
+      const array = [1, 2, 3, 4, 5];
+      const result = arrayMove(array, 0, 3);
+      expect(result).toEqual([2, 3, 4, 1, 5]);
+    });
+
+    it('should not mutate original array', () => {
+      const array = [1, 2, 3];
+      arrayMove(array, 0, 2);
+      expect(array).toEqual([1, 2, 3]);
+    });
+
+    it('should handle moving to same position', () => {
+      const array = [1, 2, 3];
+      const result = arrayMove(array, 1, 1);
+      expect(result).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('normalizeHexColor', () => {
+    it('should add # prefix if missing', () => {
+      expect(normalizeHexColor('ff0000')).toBe('#ff0000');
+    });
+
+    it('should keep # prefix if present', () => {
+      expect(normalizeHexColor('#00ff00')).toBe('#00ff00');
+    });
+
+    it('should trim whitespace', () => {
+      expect(normalizeHexColor('  #0000ff  ')).toBe('#0000ff');
+    });
+  });
+
+  describe('isValidHexColor', () => {
+    it('should validate 6-digit hex color', () => {
+      expect(isValidHexColor('#ff0000')).toBe(true);
+      expect(isValidHexColor('#00FF00')).toBe(true);
+    });
+
+    it('should validate 3-digit hex color', () => {
+      expect(isValidHexColor('#f00')).toBe(true);
+      expect(isValidHexColor('#0F0')).toBe(true);
+    });
+
+    it('should reject invalid hex colors', () => {
+      expect(isValidHexColor('#gggggg')).toBe(false);
+      expect(isValidHexColor('ff0000')).toBe(false);
+      expect(isValidHexColor('#ff00')).toBe(false);
+      expect(isValidHexColor('#ff00000')).toBe(false);
+    });
+  });
+
+  describe('isItemInSelectionBox', () => {
+    it('should return true when item is inside selection box', () => {
+      const selectionBox = {
+        endX: 200, endY: 200, startX: 0, startY: 0,
+      };
+      const item = {
+        height: 50, left: 50, top: 50, width: 50,
+      };
+      expect(isItemInSelectionBox(selectionBox, item)).toBe(true);
+    });
+
+    it('should return true when item partially overlaps', () => {
+      const selectionBox = {
+        endX: 100, endY: 100, startX: 0, startY: 0,
+      };
+      const item = {
+        height: 100, left: 50, top: 50, width: 100,
+      };
+      expect(isItemInSelectionBox(selectionBox, item)).toBe(true);
+    });
+
+    it('should return false when item is outside selection box', () => {
+      const selectionBox = {
+        endX: 100, endY: 100, startX: 0, startY: 0,
+      };
+      const item = {
+        height: 50, left: 200, top: 200, width: 50,
+      };
+      expect(isItemInSelectionBox(selectionBox, item)).toBe(false);
+    });
+
+    it('should apply zoom factor correctly', () => {
+      const selectionBox = {
+        endX: 100, endY: 100, startX: 0, startY: 0,
+      };
+      const item = {
+        height: 50, left: 25, top: 25, width: 50,
+      };
+      // With zoom 2, item bounds become 50,50 to 150,150
+      expect(isItemInSelectionBox(selectionBox, item, 2)).toBe(true);
+    });
+
+    it('should handle reversed selection box coordinates', () => {
+      const selectionBox = {
+        endX: 0, endY: 0, startX: 200, startY: 200,
+      };
+      const item = {
+        height: 50, left: 50, top: 50, width: 50,
+      };
+      expect(isItemInSelectionBox(selectionBox, item)).toBe(true);
+    });
+  });
+
+  describe('getItemsInSelectionBox', () => {
+    const items = [
+      {
+        height: 50, id: 'item1', left: 50, top: 50, width: 50,
+      },
+      {
+        height: 50, id: 'item2', left: 200, top: 200, width: 50,
+      },
+      {
+        height: 50, id: 'item3', isLocked: true, left: 75, top: 75, width: 50,
+      },
+    ];
+
+    it('should return ids of items in selection box', () => {
+      const selectionBox = {
+        endX: 150, endY: 150, startX: 0, startY: 0,
+      };
+      const result = getItemsInSelectionBox(selectionBox, items);
+      expect(result).toEqual(['item1']);
+    });
+
+    it('should exclude locked items', () => {
+      const selectionBox = {
+        endX: 200, endY: 200, startX: 0, startY: 0,
+      };
+      const result = getItemsInSelectionBox(selectionBox, items);
+      expect(result).not.toContain('item3');
+    });
+
+    it('should return empty array when no items in selection', () => {
+      const selectionBox = {
+        endX: 10, endY: 10, startX: 0, startY: 0,
+      };
+      const result = getItemsInSelectionBox(selectionBox, items);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getDimensions', () => {
+    it('should extract dimension properties', () => {
+      const input = {
+        extra: 'ignored',
+        height: 100,
+        id: 'test',
+        left: 50,
+        top: 25,
+        width: 200,
+      };
+      const result = getDimensions(input);
+      expect(result).toEqual({
+        height: 100,
+        left: 50,
+        top: 25,
+        width: 200,
+      });
+    });
+  });
+
+  describe('calculateGuidePositions', () => {
+    it('should calculate x-axis guide positions', () => {
+      const dimensions = {
+        height: 100, left: 100, top: 0, width: 200,
+      };
+      const result = calculateGuidePositions(dimensions, 'x');
+      expect(result).toEqual([100, 200, 300]);
+    });
+
+    it('should calculate y-axis guide positions', () => {
+      const dimensions = {
+        height: 100, left: 0, top: 50, width: 200,
+      };
+      const result = calculateGuidePositions(dimensions, 'y');
+      expect(result).toEqual([50, 100, 150]);
+    });
+
+    it('should apply zoom factor for items', () => {
+      const dimensions = {
+        height: 100, id: 'item1', left: 100, top: 0, width: 200,
+      };
+      const result = calculateGuidePositions(dimensions, 'x', 2);
+      expect(result).toEqual([200, 400, 600]);
+    });
+
+    it('should filter by direction for items', () => {
+      const dimensions = {
+        height: 100, id: 'item1', left: 100, top: 0, width: 200,
+      };
+      const resultLeft = calculateGuidePositions(dimensions, 'x', 1, 'left');
+      const resultRight = calculateGuidePositions(dimensions, 'x', 1, 'right');
+      expect(resultLeft).toEqual([100]);
+      expect(resultRight).toEqual([300]);
+    });
+  });
+
+  describe('getTabsWithElements', () => {
+    it('should organize config by sections', () => {
+      const config = [
+        { elements: [{ id: 'e1' }], section: 'SHAPES' },
+        { elements: [{ id: 'e2' }], section: 'IMAGES' },
+      ];
+      const result = getTabsWithElements(config);
+      expect(result).toHaveProperty('SHAPES');
+      expect(result).toHaveProperty('IMAGES');
+      expect(result.SHAPES.elements).toEqual([{ id: 'e1' }]);
+    });
+
+    it('should default to GENERAL section', () => {
+      const config = [{ elements: [{ id: 'e1' }] }];
+      const result = getTabsWithElements(config);
+      expect(result).toHaveProperty('GENERAL');
+    });
+  });
+
+  describe('emptyFunction', () => {
+    it('should return the input value unchanged', () => {
+      expect(emptyFunction(5)).toBe(5);
+      expect(emptyFunction('test')).toBe('test');
+      expect(emptyFunction(null)).toBe(null);
+    });
+  });
+});

--- a/src/__tests__/unit-tests/utils/generateId.spec.js
+++ b/src/__tests__/unit-tests/utils/generateId.spec.js
@@ -1,0 +1,57 @@
+import generateId from '../../../utils/generateId';
+
+describe('utils/generateId', () => {
+  describe('generateId', () => {
+    it('should generate id with default length of 6', () => {
+      const id = generateId();
+      expect(id).toHaveLength(6);
+    });
+
+    it('should generate id with specified length', () => {
+      const id8 = generateId(8);
+      const id10 = generateId(10);
+      const id3 = generateId(3);
+
+      expect(id8).toHaveLength(8);
+      expect(id10).toHaveLength(10);
+      expect(id3).toHaveLength(3);
+    });
+
+    it('should generate string type', () => {
+      const id = generateId();
+      expect(typeof id).toBe('string');
+    });
+
+    it('should only contain allowed characters', () => {
+      const allowedChars = '1234567890jotfrm';
+      const id = generateId(100); // longer to increase chance of catching invalid chars
+
+      for (const char of id) {
+        expect(allowedChars).toContain(char);
+      }
+    });
+
+    it('should generate unique ids', () => {
+      const ids = new Set();
+      const count = 100;
+
+      for (let i = 0; i < count; i++) {
+        ids.add(generateId());
+      }
+
+      // While collisions are theoretically possible, they should be extremely rare
+      expect(ids.size).toBe(count);
+    });
+
+    it('should generate different ids on consecutive calls', () => {
+      const id1 = generateId();
+      const id2 = generateId();
+      const id3 = generateId();
+
+      // These should all be different (extremely high probability)
+      expect(id1).not.toBe(id2);
+      expect(id2).not.toBe(id3);
+      expect(id1).not.toBe(id3);
+    });
+  });
+});

--- a/src/__tests__/unit-tests/utils/hooks.spec.js
+++ b/src/__tests__/unit-tests/utils/hooks.spec.js
@@ -1,0 +1,318 @@
+/**
+ * @jest-environment jsdom
+ */
+import React, { useState, useEffect } from 'react';
+import { mount } from 'enzyme';
+import {
+  useStateWithCallback,
+  useEventListener,
+  useInterval,
+  usePrevious,
+  usePropState,
+  usePageTransition,
+} from '../../../utils/hooks';
+
+// Mock the context stores since they're not needed for basic hook tests
+jest.mock('../../../contexts/PropContext', () => ({
+  usePropStore: jest.fn(),
+}));
+
+jest.mock('../../../contexts/BuilderContext', () => ({
+  useBuilderStore: jest.fn(),
+}));
+
+jest.mock('../../../contexts/PresentationContext', () => ({
+  usePresentationStore: jest.fn(),
+}));
+
+// Helper component to test hooks
+const TestHookComponent = ({ hook, hookArgs = [], onResult }) => {
+  const result = hook(...hookArgs);
+  useEffect(() => {
+    onResult(result);
+  }, [result, onResult]);
+  return null;
+};
+
+describe('utils/hooks', () => {
+  describe('useStateWithCallback', () => {
+    it('should call callback when state changes', () => {
+      const callback = jest.fn();
+      let hookResult;
+
+      const TestComponent = () => {
+        const [state, setState] = useStateWithCallback('initial', callback);
+        hookResult = { setState, state };
+        return <div>{state}</div>;
+      };
+
+      mount(<TestComponent />);
+      expect(callback).toHaveBeenCalledWith('initial');
+    });
+  });
+
+  describe('useEventListener', () => {
+    it('should add event listener to element', () => {
+      const handler = jest.fn();
+      const addSpy = jest.fn();
+      const removeSpy = jest.fn();
+      const element = {
+        addEventListener: addSpy,
+        removeEventListener: removeSpy,
+      };
+
+      const TestComponent = () => {
+        useEventListener('click', handler, element);
+        return null;
+      };
+
+      mount(<TestComponent />);
+      expect(addSpy).toHaveBeenCalledWith('click', expect.any(Function));
+    });
+
+    it('should call handler when event fires', () => {
+      const handler = jest.fn();
+      let eventCallback;
+      const element = {
+        addEventListener: jest.fn((event, cb) => {
+          eventCallback = cb;
+        }),
+        removeEventListener: jest.fn(),
+      };
+
+      const TestComponent = () => {
+        useEventListener('click', handler, element);
+        return null;
+      };
+
+      mount(<TestComponent />);
+
+      const mockEvent = { type: 'click' };
+      eventCallback(mockEvent);
+
+      expect(handler).toHaveBeenCalledWith(mockEvent);
+    });
+  });
+
+  describe('useInterval', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should call callback at specified interval', () => {
+      const callback = jest.fn();
+
+      const TestComponent = () => {
+        useInterval(callback, 1000);
+        return null;
+      };
+
+      mount(<TestComponent />);
+
+      expect(callback).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(1000);
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      jest.advanceTimersByTime(1000);
+      expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not call callback when delay is null', () => {
+      const callback = jest.fn();
+
+      const TestComponent = () => {
+        useInterval(callback, null);
+        return null;
+      };
+
+      mount(<TestComponent />);
+
+      jest.advanceTimersByTime(5000);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should clear interval on unmount', () => {
+      // Note: Due to enzyme's async behavior with useEffect cleanup,
+      // this test verifies the interval is created and runs
+      const callback = jest.fn();
+
+      const TestComponent = () => {
+        useInterval(callback, 1000);
+        return null;
+      };
+
+      mount(<TestComponent />);
+
+      jest.advanceTimersByTime(2000);
+      expect(callback.mock.calls.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('usePrevious', () => {
+    it('should return undefined on first render', () => {
+      let previousValue;
+
+      const TestComponent = () => {
+        previousValue = usePrevious('initial');
+        return null;
+      };
+
+      mount(<TestComponent />);
+      expect(previousValue).toBeUndefined();
+    });
+
+    it('should return previous value after update', () => {
+      let previousValue;
+
+      const TestComponent = ({ value }) => {
+        previousValue = usePrevious(value);
+        return <div>{value}</div>;
+      };
+
+      const wrapper = mount(<TestComponent value="first" />);
+      expect(previousValue).toBeUndefined();
+
+      wrapper.setProps({ value: 'second' });
+      expect(previousValue).toBe('first');
+
+      wrapper.setProps({ value: 'third' });
+      expect(previousValue).toBe('second');
+    });
+  });
+
+  describe('usePropState', () => {
+    it('should initialize with prop value', () => {
+      let stateValue;
+
+      const TestComponent = () => {
+        const [state] = usePropState('initial');
+        stateValue = state;
+        return null;
+      };
+
+      mount(<TestComponent />);
+      expect(stateValue).toBe('initial');
+    });
+
+    it('should apply transform function on initialization', () => {
+      let stateValue;
+      const transform = value => value.toUpperCase();
+
+      const TestComponent = () => {
+        const [state] = usePropState('hello', transform);
+        stateValue = state;
+        return null;
+      };
+
+      mount(<TestComponent />);
+      expect(stateValue).toBe('HELLO');
+    });
+
+    it('should update when prop changes', () => {
+      let stateValue;
+
+      const TestComponent = ({ propValue }) => {
+        const [state] = usePropState(propValue);
+        stateValue = state;
+        return null;
+      };
+
+      const wrapper = mount(<TestComponent propValue="initial" />);
+      expect(stateValue).toBe('initial');
+
+      wrapper.setProps({ propValue: 'updated' });
+      expect(stateValue).toBe('updated');
+    });
+  });
+
+  describe('usePageTransition', () => {
+    it('should return horizontal slide transform by default', () => {
+      let styleValue;
+
+      const TestComponent = () => {
+        styleValue = usePageTransition('horizontalSlide', 2);
+        return null;
+      };
+
+      mount(<TestComponent />);
+      expect(styleValue).toEqual({ transform: 'translateX(-200%)' });
+    });
+
+    it('should return vertical slide transform', () => {
+      let styleValue;
+
+      const TestComponent = () => {
+        styleValue = usePageTransition('verticalSlide', 3);
+        return null;
+      };
+
+      mount(<TestComponent />);
+      expect(styleValue).toEqual({ transform: 'translateY(-300%)' });
+    });
+
+    it('should return empty object for scaleAndFade', () => {
+      let styleValue;
+
+      const TestComponent = () => {
+        styleValue = usePageTransition('scaleAndFade', 1);
+        return null;
+      };
+
+      mount(<TestComponent />);
+      expect(styleValue).toEqual({});
+    });
+
+    it('should return perspective for rotate', () => {
+      let styleValue;
+
+      const TestComponent = () => {
+        styleValue = usePageTransition('rotate', 0);
+        return null;
+      };
+
+      mount(<TestComponent />);
+      expect(styleValue).toEqual({ '-webkit-perspective': 1000 });
+    });
+
+    it('should return horizontal transform for scaleAndSlide', () => {
+      let styleValue;
+
+      const TestComponent = () => {
+        styleValue = usePageTransition('scaleAndSlide', 1);
+        return null;
+      };
+
+      mount(<TestComponent />);
+      expect(styleValue).toEqual({ transform: 'translateX(-100%)' });
+    });
+
+    it('should default to horizontal slide for unknown style', () => {
+      let styleValue;
+
+      const TestComponent = () => {
+        styleValue = usePageTransition('unknown', 2);
+        return null;
+      };
+
+      mount(<TestComponent />);
+      expect(styleValue).toEqual({ transform: 'translateX(-200%)' });
+    });
+
+    it('should handle page 0', () => {
+      let styleValue;
+
+      const TestComponent = () => {
+        styleValue = usePageTransition('horizontalSlide', 0);
+        return null;
+      };
+
+      mount(<TestComponent />);
+      expect(styleValue).toEqual({ transform: 'translateX(-0%)' });
+    });
+  });
+});

--- a/src/__tests__/unit-tests/utils/string.spec.js
+++ b/src/__tests__/unit-tests/utils/string.spec.js
@@ -1,0 +1,103 @@
+import { capitalize, slugify, stripHTML } from '../../../utils/string';
+
+describe('utils/string', () => {
+  describe('capitalize', () => {
+    it('should capitalize first letter of string', () => {
+      expect(capitalize('hello')).toBe('Hello');
+    });
+
+    it('should handle already capitalized string', () => {
+      expect(capitalize('Hello')).toBe('Hello');
+    });
+
+    it('should handle single character', () => {
+      expect(capitalize('a')).toBe('A');
+    });
+
+    it('should handle empty string', () => {
+      expect(capitalize('')).toBe('');
+    });
+
+    it('should return non-string values unchanged', () => {
+      expect(capitalize(123)).toBe(123);
+      expect(capitalize(null)).toBe(null);
+      expect(capitalize(undefined)).toBe(undefined);
+    });
+
+    it('should capitalize only first letter', () => {
+      expect(capitalize('hELLO WORLD')).toBe('HELLO WORLD');
+    });
+  });
+
+  describe('slugify', () => {
+    it('should convert string to lowercase slug', () => {
+      expect(slugify('Hello World')).toBe('hello-world');
+    });
+
+    it('should replace spaces with hyphens', () => {
+      expect(slugify('multiple   spaces   here')).toBe('multiple-spaces-here');
+    });
+
+    it('should replace & with and', () => {
+      expect(slugify('salt & pepper')).toBe('salt-and-pepper');
+    });
+
+    it('should remove special characters', () => {
+      expect(slugify('Hello! World?')).toBe('hello-world');
+    });
+
+    it('should handle accented characters', () => {
+      // The function removes accented characters but doesn't normalize them
+      expect(slugify('café résumé')).toBe('caf-rsum');
+    });
+
+    it('should trim whitespace', () => {
+      expect(slugify('  hello world  ')).toBe('hello-world');
+    });
+
+    it('should collapse multiple hyphens', () => {
+      expect(slugify('hello---world')).toBe('hello-world');
+    });
+
+    it('should handle empty string', () => {
+      expect(slugify('')).toBe('');
+    });
+
+    it('should handle numbers', () => {
+      expect(slugify('item 1 and item 2')).toBe('item-1-and-item-2');
+    });
+  });
+
+  describe('stripHTML', () => {
+    it('should remove HTML tags from string', () => {
+      expect(stripHTML('<p>Hello World</p>')).toBe('Hello World');
+    });
+
+    it('should handle nested tags', () => {
+      expect(stripHTML('<div><p><strong>Bold</strong> text</p></div>')).toBe('Bold text');
+    });
+
+    it('should return string without HTML tags unchanged', () => {
+      expect(stripHTML('plain text')).toBe('plain text');
+    });
+
+    it('should handle empty tags', () => {
+      // stripHTML only processes strings containing both < and >
+      // If no text content, returns original
+      expect(stripHTML('<div></div>')).toBe('<div></div>');
+    });
+
+    it('should handle self-closing tags', () => {
+      expect(stripHTML('Line 1<br/>Line 2')).toBe('Line 1Line 2');
+    });
+
+    it('should handle strings with only > or <', () => {
+      expect(stripHTML('5 > 3')).toBe('5 > 3');
+      expect(stripHTML('3 < 5')).toBe('3 < 5');
+    });
+
+    it('should handle HTML entities', () => {
+      expect(stripHTML('<p>&amp; &lt; &gt;</p>')).toBe('& < >');
+    });
+  });
+});

--- a/src/components/PageItemResizer.js
+++ b/src/components/PageItemResizer.js
@@ -3,6 +3,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import PropTypes from 'prop-types';
 import { Resizable } from 're-resizable';
 import { createPortal } from 'react-dom';
 import classNames from 'classnames';
@@ -163,6 +164,21 @@ const PageItemResizer = ({
     </ItemPositioner>,
     document.querySelector(`.jfReport-page[data-id="${item.pageID}"]`),
   );
+};
+
+PageItemResizer.propTypes = {
+  item: PropTypes.shape({
+    height: PropTypes.number.isRequired,
+    id: PropTypes.string.isRequired,
+    isLocked: PropTypes.bool,
+    itemType: PropTypes.string,
+    left: PropTypes.number.isRequired,
+    pageID: PropTypes.string.isRequired,
+    top: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+  }).isRequired,
+  onResize: PropTypes.func.isRequired,
+  onResizeStop: PropTypes.func.isRequired,
 };
 
 export default PageItemResizer;

--- a/src/components/Print/Print.js
+++ b/src/components/Print/Print.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import PrintWrapper from './PrintWrapper';
 import Providers from '../../contexts/Providers';
 import ReportWrapper from '../ReportWrapper';
@@ -21,6 +22,13 @@ const Print = props => {
       </PrintWrapper>
     </Providers>
   );
+};
+
+Print.propTypes = {
+  acceptedItems: PropTypes.shape({}),
+  pages: PropTypes.arrayOf(PropTypes.object),
+  settings: PropTypes.shape({}),
+  theme: PropTypes.oneOf(['lightMode', 'darkMode']),
 };
 
 export default Print;

--- a/src/components/ResponsiveContent.js
+++ b/src/components/ResponsiveContent.js
@@ -1,7 +1,14 @@
 import { memo } from 'react';
+import PropTypes from 'prop-types';
 
 const ResponsiveContent = ({ children, height, width }) => {
   return children(width, height);
+};
+
+ResponsiveContent.propTypes = {
+  children: PropTypes.func.isRequired,
+  height: PropTypes.number.isRequired,
+  width: PropTypes.number.isRequired,
 };
 
 export default memo(ResponsiveContent);


### PR DESCRIPTION
## What:
Adds missing PropTypes definitions to several components.

## Why:
- Improves code maintainability and type safety
- Better IDE autocomplete and developer experience
- Runtime prop validation in development mode
- Follows React best practices

## How:
Added PropTypes to:
- `PageItemResizer.js` - Resizer component props
- `ResponsiveContent.js` - Responsive wrapper props
- `Print/Print.js` - Print component props

## Checklist:
- [ ] Documentation added to the docs site
- [ ] Tests
- [x] Ready to be merged