### PR TITLE
feat: add properties to control zoom and zoom controls visibility

### DIFF
--- a/src/components/Builder/Scene.js
+++ b/src/components/Builder/Scene.js
@@ -37,6 +37,7 @@ const Scene = () => {
   const slidesListType = useBuilderStore(state => state.slidesListType);
   const setOverPage = useBuilderStore(state => state.setOverPage);
   const setOutPage = useBuilderStore(state => state.setOutPage);
+  const shouldShowZoomControls = useBuilderStore(state => state.shouldShowZoomControls);
 
   const pageStyles = useRef({});
   const pageContainerStyles = useRef({});
@@ -177,7 +178,7 @@ const Scene = () => {
       </div>
       <div className="bottom-actions-container">
         {isSlidesListType(slidesListType, 'NAVIGATOR') && <SlidesNavigatorToggle />}
-        <ZoomControls />
+        {shouldShowZoomControls && <ZoomControls />}
       </div>
       {contextMenuProps
         && (

--- a/src/contexts/BuilderContext.js
+++ b/src/contexts/BuilderContext.js
@@ -196,10 +196,12 @@ const builderStore = props => {
         }
       }
     },
+    shouldFitZoomInitially: !!props.defaultZoom,
     shouldShowRightPanelInitially: props.shouldShowRightPanelInitially ?? true,
+    shouldShowZoomControls: props.shouldShowZoomControls ?? true,
     slidesListType: props.slidesListType || SLIDES_LIST_TYPE_MAP.PANEL,
     visiblePageOrder: 1,
-    zoom: 0.8,
+    zoom: props.defaultZoom ?? 0.8,
   }));
 };
 

--- a/src/contexts/Providers.js
+++ b/src/contexts/Providers.js
@@ -7,11 +7,13 @@ import { SLIDES_LIST_TYPE_MAP } from '../constants/panel';
 const Providers = ({
   children,
   clickOutsideIgnoreSelectors,
+  defaultZoom,
   lastScrollPosition,
   mode,
   onRightPanelsToggled,
   presentationBarActions,
   shouldShowRightPanelInitially,
+  shouldShowZoomControls,
   slidesListType,
   useFixedPresentationBar,
   ...props
@@ -19,9 +21,11 @@ const Providers = ({
   return (
     <BuilderProvider
       clickOutsideIgnoreSelectors={clickOutsideIgnoreSelectors}
+      defaultZoom={defaultZoom}
       lastScrollPosition={lastScrollPosition}
       onRightPanelsToggled={onRightPanelsToggled}
       shouldShowRightPanelInitially={shouldShowRightPanelInitially}
+      shouldShowZoomControls={shouldShowZoomControls}
       slidesListType={slidesListType}
     >
       <PropProvider {...props}>
@@ -42,6 +46,8 @@ Providers.propTypes = {
   children: PropTypes.node.isRequired,
   /** CSS selectors ignored by right panel click-outside logic */
   clickOutsideIgnoreSelectors: PropTypes.arrayOf(PropTypes.string),
+  /** Default zoom */
+  defaultZoom: PropTypes.number,
   /** Last scroll position */
   lastScrollPosition: PropTypes.number,
   /** Mode of the report */
@@ -55,6 +61,8 @@ Providers.propTypes = {
   presentationBarActions: PropTypes.arrayOf(PropTypes.shape({})),
   /** Flag for fixed action bar */
   shouldShowRightPanelInitially: PropTypes.bool,
+  /** Flag for whether to show the zoom controls */
+  shouldShowZoomControls: PropTypes.bool,
   /** Flag for whether to show the right panel initially */
   slidesListType: PropTypes.oneOf(Object.values(SLIDES_LIST_TYPE_MAP)),
   /** Slides list type for the report */

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -104,21 +104,25 @@ export const usePropState = (propValue, transform = v => v) => {
 export const useFitZoom = () => {
   const settings = usePropStore(state => state.settings);
   const setZoom = useBuilderStore(state => state.setZoom);
+  const shouldFitZoomInitially = useBuilderStore(state => state.shouldFitZoomInitially);
 
   useEffect(() => {
-    const fitZoom = getZoomValue({
-      limitZoom: true,
-      settings: {
-        reportLayoutHeight: settings.reportLayoutHeight,
-        reportLayoutWidth: settings.reportLayoutWidth,
-      },
-    });
-    const newZoom = Math.min(fitZoom, INITIAL_ZOOM_MAX);
-    setZoom(newZoom, settings.reportLayoutWidth);
+    if (shouldFitZoomInitially) {
+      const fitZoom = getZoomValue({
+        limitZoom: true,
+        settings: {
+          reportLayoutHeight: settings.reportLayoutHeight,
+          reportLayoutWidth: settings.reportLayoutWidth,
+        },
+      });
+      const newZoom = Math.min(fitZoom, INITIAL_ZOOM_MAX);
+      setZoom(newZoom, settings.reportLayoutWidth);
+    }
   }, [
     settings.reportLayoutHeight,
     settings.reportLayoutWidth,
     setZoom,
+    shouldFitZoomInitially,
   ]);
 };
 


### PR DESCRIPTION
Introduces `defaultZoom` and `shouldShowZoomControls` props to the Builder. Providing a `defaultZoom` value now overrides the initial auto-fit logic, while `shouldShowZoomControls` allows for toggling the visibility of the zoom UI.
