### PR TITLE
fix: improve zoom behavior and responsiveness in preview mode

### DIFF
--- a/src/components/Builder/Scene.js
+++ b/src/components/Builder/Scene.js
@@ -37,7 +37,6 @@ const Scene = () => {
   const slidesListType = useBuilderStore(state => state.slidesListType);
   const setOverPage = useBuilderStore(state => state.setOverPage);
   const setOutPage = useBuilderStore(state => state.setOutPage);
-  const shouldShowZoomControls = useBuilderStore(state => state.shouldShowZoomControls);
 
   const pageStyles = useRef({});
   const pageContainerStyles = useRef({});
@@ -178,7 +177,7 @@ const Scene = () => {
       </div>
       <div className="bottom-actions-container">
         {isSlidesListType(slidesListType, 'NAVIGATOR') && <SlidesNavigatorToggle />}
-        {shouldShowZoomControls && <ZoomControls />}
+        <ZoomControls />
       </div>
       {contextMenuProps
         && (

--- a/src/components/Builder/ZoomControls.js
+++ b/src/components/Builder/ZoomControls.js
@@ -7,12 +7,17 @@ import {
   ZOOM_MIN,
   ZOOM_MAX,
   ZOOM_MULTIPLIER,
+  ZOOM_MOBILE_MIN,
+  ZOOM_MOBILE_MAX,
 } from '../../constants/zoom';
-import { useTranslatedTexts } from '../../utils/hooks';
+import { useResizeListener, useTranslatedTexts } from '../../utils/hooks';
 
 const ZoomControls = () => {
   const setZoom = useBuilderStore(state => state.setZoom);
   const zoom = useBuilderStore(state => state.zoom);
+  const resizedWidth = useResizeListener();
+  const minZoom = resizedWidth < 768 ? ZOOM_MOBILE_MIN : ZOOM_MIN;
+  const maxZoom = resizedWidth < 768 ? ZOOM_MOBILE_MAX : ZOOM_MAX;
 
   const onAnEventTrigger = usePropStore(state => state.onAnEventTrigger);
   const settings = usePropStore(state => state.settings);
@@ -20,13 +25,13 @@ const ZoomControls = () => {
   const { reportLayoutHeight = 794, reportLayoutWidth = 1123 } = settings;
   const decreaseZoom = () => {
     onAnEventTrigger('zoomOut', 'report');
-    if (zoom > (ZOOM_STEP + ZOOM_MIN)) {
+    if (zoom > minZoom) {
       setZoom(parseFloat((zoom - ZOOM_STEP).toFixed(1)), reportLayoutWidth);
     }
   };
   const increaseZoom = () => {
     onAnEventTrigger('zoomIn', 'report');
-    if (zoom < (ZOOM_MAX)) {
+    if (zoom < maxZoom) {
       setZoom(parseFloat((zoom + ZOOM_STEP).toFixed(1)), reportLayoutWidth);
     }
   };

--- a/src/components/Preview/StaticScene.js
+++ b/src/components/Preview/StaticScene.js
@@ -39,6 +39,8 @@ const StaticScene = ({
   } = settings;
   const width = parseInt(reportLayoutWidth, 10);
   const height = parseInt(reportLayoutHeight, 10);
+  const zoomToUse = Number.isNaN(zoom) ? 1 : zoom;
+  const isPreviewCssZoom = mode === 'preview';
 
   useEffect(() => {
     transformRefs.current = transformRefs.current.slice(0, pages.length);
@@ -60,12 +62,15 @@ const StaticScene = ({
   }, [setZoom]);
 
   useEffect(() => {
+    if (mode !== 'presentation') {
+      return;
+    }
     if (transformRefs.current.length > 0) {
       for (let i = 0; i < pages.length; i++) {
-        transformRefs.current[i].centerView(zoom);
+        transformRefs.current[i]?.centerView?.(zoom);
       }
     }
-  }, [pages.length, zoom]);
+  }, [pages.length, zoom, mode]);
 
   const isEnabledZoomControls = (!isFullscreen || (isFullscreen && showControlsInFullScreen)) && !hideZoom;
 
@@ -76,6 +81,7 @@ const StaticScene = ({
       <div
         ref={viewPortRef}
         className={classNames.viewport}
+        data-zoom={isPreviewCssZoom ? zoom : undefined}
         {...gesture()}
       >
         <div
@@ -84,10 +90,25 @@ const StaticScene = ({
         >
           {pages.map((page, index) => {
             const { backgroundColor } = page;
-            const style = {
+            const bg = backgroundColor ? backgroundColor : reportBackgroundColor || '#fff';
+
+            const style = isPreviewCssZoom ? {
+              backgroundColor: bg,
+              height,
+              transform: `scale(${zoomToUse})`,
+              transformOrigin: '0 0',
+              width,
+            } : {
               ...pageContainerStyles,
-              backgroundColor: backgroundColor ? backgroundColor : reportBackgroundColor || '#fff',
+              backgroundColor: bg,
             };
+
+            const pageOuterStyle = isPreviewCssZoom ? {
+              height: parseFloat((height * zoomToUse).toFixed(1)),
+              position: 'relative',
+              width: parseFloat((width * zoomToUse).toFixed(1)),
+            } : undefined;
+
             return (
               <div
                 key={`page_${index.toString()}`}
@@ -98,6 +119,7 @@ const StaticScene = ({
                 })}
                 data-id={page.id}
                 id={`presentation-page-${page.id.toString()}`}
+                style={pageOuterStyle}
               >
                 <StaticPageWithZoomPanPinch
                   handleZoom={handleZoom}
@@ -111,7 +133,11 @@ const StaticScene = ({
           })}
         </div>
       </div>
-      {isEnabledZoomControls && <ZoomControls />}
+      {isEnabledZoomControls && (
+        <div className="bottom-actions-container">
+          <ZoomControls />
+        </div>
+      )}
     </main>
   );
 };

--- a/src/constants/zoom.js
+++ b/src/constants/zoom.js
@@ -1,4 +1,6 @@
 export const ZOOM_MAX = 2;
-export const ZOOM_MIN = 0.4;
+export const ZOOM_MOBILE_MAX = 1;
+export const ZOOM_MIN = 0.5;
+export const ZOOM_MOBILE_MIN = 0.2;
 export const ZOOM_STEP = 0.1;
 export const ZOOM_MULTIPLIER = 100;

--- a/src/contexts/BuilderContext.js
+++ b/src/contexts/BuilderContext.js
@@ -181,7 +181,7 @@ const builderStore = props => {
     },
     setZoom: (zoom, layoutWidth) => {
       set({ zoom });
-      if (layoutWidth) {
+      if (layoutWidth && get().mode === 'customize') {
         const { clientWidth: paneWidth } = document.querySelector('.jfReport-pane .toolItemWrapper');
         const sceneWidth = parseInt(layoutWidth, 10) * zoom;
         if (window.innerWidth - sceneWidth + 100 > (paneWidth * 2)) {
@@ -198,7 +198,6 @@ const builderStore = props => {
     },
     shouldFitZoomInitially: !!props.defaultZoom,
     shouldShowRightPanelInitially: props.shouldShowRightPanelInitially ?? true,
-    shouldShowZoomControls: props.shouldShowZoomControls ?? true,
     slidesListType: props.slidesListType || SLIDES_LIST_TYPE_MAP.PANEL,
     visiblePageOrder: 1,
     zoom: props.defaultZoom ?? 0.8,

--- a/src/contexts/Providers.js
+++ b/src/contexts/Providers.js
@@ -13,7 +13,6 @@ const Providers = ({
   onRightPanelsToggled,
   presentationBarActions,
   shouldShowRightPanelInitially,
-  shouldShowZoomControls,
   slidesListType,
   useFixedPresentationBar,
   ...props
@@ -25,7 +24,6 @@ const Providers = ({
       lastScrollPosition={lastScrollPosition}
       onRightPanelsToggled={onRightPanelsToggled}
       shouldShowRightPanelInitially={shouldShowRightPanelInitially}
-      shouldShowZoomControls={shouldShowZoomControls}
       slidesListType={slidesListType}
     >
       <PropProvider {...props}>
@@ -61,8 +59,6 @@ Providers.propTypes = {
   presentationBarActions: PropTypes.arrayOf(PropTypes.shape({})),
   /** Flag for fixed action bar */
   shouldShowRightPanelInitially: PropTypes.bool,
-  /** Flag for whether to show the zoom controls */
-  shouldShowZoomControls: PropTypes.bool,
   /** Flag for whether to show the right panel initially */
   slidesListType: PropTypes.oneOf(Object.values(SLIDES_LIST_TYPE_MAP)),
   /** Slides list type for the report */

--- a/src/styles/_jfReportsViewModes.scss
+++ b/src/styles/_jfReportsViewModes.scss
@@ -1,6 +1,7 @@
 .jfReport.previewMode {
+  /* Match customizeMode horizontal rhythm so preview/static aligns with the builder canvas. */
   .jfReport-canvas {
-    padding: 0 40px;
+    padding: 0 120px;
   }
 
   .jfReport-page {

--- a/src/styles/_jfReportsViewModes.scss
+++ b/src/styles/_jfReportsViewModes.scss
@@ -1,5 +1,4 @@
 .jfReport.previewMode {
-  /* Match customizeMode horizontal rhythm so preview/static aligns with the builder canvas. */
   .jfReport-canvas {
     padding: 0 120px;
   }


### PR DESCRIPTION
Refactors zoom implementation in preview mode to use CSS scaling, ensuring visual alignment with the builder canvas. This change also introduces responsive zoom limits for mobile devices and simplifies zoom control visibility logic.

- Implements CSS transform-based zooming for the preview scene
- Adds mobile-specific min/max zoom constants
- Adjusts preview canvas padding to match the builder's layout rhythm
- Removes the manual toggle for zoom controls in favor of standard visibility rules