### PR TITLE
feat(dnd-builder): Introduce controlled actions for draggable items

### DIFF
--- a/src/__tests__/unit-tests/Builder/RightPanel/rightPanel.spec.js
+++ b/src/__tests__/unit-tests/Builder/RightPanel/rightPanel.spec.js
@@ -9,64 +9,74 @@ import { mountWithProviders } from '../../../../__test_helpers__/utils';
 
 
 describe('RightPanel Component', () => {
+  const mountRightPanel = (options = {}) => {
+    return mountWithProviders(<RightPanel />, {
+      ...options,
+      propProps: {
+        itemAccessor: () => ({}),
+        ...(options.propProps || {}),
+      },
+    });
+  };
+
   it('Should Always Render Panel in RightPanel', () => {
-    const rightPanelWrapper = mountWithProviders(<RightPanel />);
+    const rightPanelWrapper = mountRightPanel();
     expect(rightPanelWrapper.find(Panel)).toHaveLength(1);
   });
 
   it('Should Always Render RightPanelToggler in RightPanel', () => {
-    const rightPanelWrapper = mountWithProviders(<RightPanel />);
+    const rightPanelWrapper = mountRightPanel();
     expect(rightPanelWrapper.find(RightPanelToggler)).toHaveLength(1);
   });
 
   it('Should Always Render Section in RightPanel', () => {
-    const rightPanelWrapper = mountWithProviders(<RightPanel />);
+    const rightPanelWrapper = mountRightPanel();
     expect(rightPanelWrapper.find(Section)).toHaveLength(1);
   });
 
   it('Should Always Render Tabs in RightPanel', () => {
-    const rightPanelWrapper = mountWithProviders(<RightPanel />);
+    const rightPanelWrapper = mountRightPanel();
     expect(rightPanelWrapper.find(Tabs)).toHaveLength(1);
   });
 
   it('Should Always Render Settings in RightPanel', () => {
-    const rightPanelWrapper = mountWithProviders(<RightPanel />);
+    const rightPanelWrapper = mountRightPanel();
     expect(rightPanelWrapper.find(Settings)).toHaveLength(1);
   });
 
   it('Section contains Tabs & Settings', () => {
-    const rightPanelWrapper = mountWithProviders(<RightPanel />);
+    const rightPanelWrapper = mountRightPanel();
     expect(rightPanelWrapper.find(Tabs).parent().is(Section)).toEqual(true);
     expect(rightPanelWrapper.find(Settings).parent().is(Section)).toEqual(true);
   });
 
   it('Should Not Pass isIdle Class to Panel If `isRightPanelOpen` is `true`', () => {
-    const builderWrapper = mountWithProviders(<RightPanel />, { builderProps: { isRightPanelOpen: true } });
+    const builderWrapper = mountRightPanel({ builderProps: { isRightPanelOpen: true } });
     expect(builderWrapper.find(Panel).props().additionalClassName).not.toMatch('isIdle');
   });
 
   it('Should Pass isIdle Class to Panel If `isRightPanelOpen` is `false`', () => {
-    const builderWrapper = mountWithProviders(<RightPanel />);
+    const builderWrapper = mountRightPanel();
     expect(builderWrapper.find(Panel).props().additionalClassName).toMatch('isIdle');
   });
 
   it('Should Not Pass otherOpened Class to Panel If `isSlidesPanelOpen` is `false`', () => {
-    const builderWrapper = mountWithProviders(<RightPanel />);
+    const builderWrapper = mountRightPanel();
     expect(builderWrapper.find(Panel).props().additionalClassName).not.toMatch('otherOpened');
   });
 
   it('Should Pass otherOpened Class to Panel If `isSlidesPanelOpen` is `true`', () => {
-    const builderWrapper = mountWithProviders(<RightPanel />, { builderProps: { isSlidesPanelOpen: true } });
+    const builderWrapper = mountRightPanel({ builderProps: { isSlidesPanelOpen: true } });
     expect(builderWrapper.find(Panel).props().additionalClassName).toMatch('otherOpened');
   });
 
   it('Should Render `RightPanelToggler` with `paneClose` class name If `isRightPanelOpen` is `true`', () => {
-    const builderWrapper = mountWithProviders(<RightPanel />, { builderProps: { isRightPanelOpen: true } });
+    const builderWrapper = mountRightPanel({ builderProps: { isRightPanelOpen: true } });
     expect(builderWrapper.find('.paneClose')).toHaveLength(1);
   });
 
   it('Should Not Render `RightPanelToggler` If `isSlidesPanelOpen` is `true`', () => {
-    const builderWrapper = mountWithProviders(<RightPanel />, { builderProps: { isSlidesPanelOpen: true } });
+    const builderWrapper = mountRightPanel({ builderProps: { isSlidesPanelOpen: true } });
     expect(builderWrapper.find(Panel).props().additionalClassName).toMatch('isIdle');
     expect(builderWrapper.find(RightPanelToggler)).toHaveLength(0);
   });

--- a/src/components/DraggableItem/DraggableItem.js
+++ b/src/components/DraggableItem/DraggableItem.js
@@ -229,12 +229,23 @@ const DraggableItemContent = ({
     });
   };
 
+  const itemAccessor = usePropStore(state => state.itemAccessor);
+  const accessorItemData = useMemo(() => {
+    return itemAccessor(item);
+  }, [item, itemAccessor]);
+
+  const { actions = { settings: true } } = accessorItemData;
+
   const onDoubleClick = e => {
     if (
       e.target.contentEditable === 'true'
       || isTextEditorOpen
     ) {
       // Dont override behaviour on text edits.
+      return;
+    }
+
+    if (!actions.settings) {
       return;
     }
 

--- a/src/components/DraggableItem/DraggableItemActions.js
+++ b/src/components/DraggableItem/DraggableItemActions.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import * as icons from '../../utils/icons';
 import { useSelectedElements, useTranslatedTexts } from '../../utils/hooks';
 import { usePropStore } from '../../contexts/PropContext';
@@ -14,7 +15,14 @@ const toolbarAlignForItem = (state, selectedId) => {
   return position ?? DEFAULT_TOOLBAR_ALIGN;
 };
 
-const DraggableItemActions = () => {
+const DraggableItemActions = ({
+  actions = {
+    delete: true,
+    duplicate: true,
+    lock: true,
+    settings: true,
+  },
+}) => {
   const {
     DELETE_ITEM,
     DUPLICATE_ITEM,
@@ -86,40 +94,57 @@ const DraggableItemActions = () => {
   }
   return (
     <div className={`report-item-toolbar ${position}`}>
-      <button
-        className="report-item-toolbar-item"
-        onClick={openSettings}
-        title={ITEM_SETTINGS}
-        type="button"
-      >
-        <icons.settings className="toolbar-icon" />
-      </button>
-      <button
-        className="report-item-toolbar-item"
-        onClick={duplicateItem}
-        title={DUPLICATE_ITEM}
-        type="button"
-      >
-        <icons.duplicate className="toolbar-icon" />
-      </button>
-      <button
-        className="report-item-toolbar-item"
-        onClick={changeLockStatus}
-        title={LOCK_ITEM}
-        type="button"
-      >
-        <icons.unlock className="toolbar-icon" />
-      </button>
-      <button
-        className="report-item-toolbar-item error"
-        onClick={deleteItem}
-        title={DELETE_ITEM}
-        type="button"
-      >
-        <icons.trash className="toolbar-icon" />
-      </button>
+      {actions.settings && (
+        <button
+          className="report-item-toolbar-item"
+          onClick={openSettings}
+          title={ITEM_SETTINGS}
+          type="button"
+        >
+          <icons.settings className="toolbar-icon" />
+        </button>
+      )}
+      {actions.duplicate && (
+        <button
+          className="report-item-toolbar-item"
+          onClick={duplicateItem}
+          title={DUPLICATE_ITEM}
+          type="button"
+        >
+          <icons.duplicate className="toolbar-icon" />
+        </button>
+      )}
+      {actions.lock && (
+        <button
+          className="report-item-toolbar-item"
+          onClick={changeLockStatus}
+          title={LOCK_ITEM}
+          type="button"
+        >
+          <icons.unlock className="toolbar-icon" />
+        </button>
+      )}
+      {actions.delete && (
+        <button
+          className="report-item-toolbar-item error"
+          onClick={deleteItem}
+          title={DELETE_ITEM}
+          type="button"
+        >
+          <icons.trash className="toolbar-icon" />
+        </button>
+      )}
     </div>
   );
+};
+
+DraggableItemActions.propTypes = {
+  actions: PropTypes.shape({
+    delete: PropTypes.bool,
+    duplicate: PropTypes.bool,
+    lock: PropTypes.bool,
+    settings: PropTypes.bool,
+  }),
 };
 
 export default DraggableItemActions;

--- a/src/components/PageItemResizer.js
+++ b/src/components/PageItemResizer.js
@@ -13,6 +13,7 @@ import DraggableItemActions from './DraggableItem/DraggableItemActions';
 import ItemPositioner from './ItemPositioner';
 import withClickOutside from './withClickOutside';
 import { useBuilderStore } from '../contexts/BuilderContext';
+import { usePropStore } from '../contexts/PropContext';
 
 const exceptionalClassesForClickOutside = ['contextMenu-itemLabel', 'contextMenu-item'];
 const ResizableWithClickOutside = withClickOutside(Resizable);
@@ -53,6 +54,7 @@ const PageItemResizer = ({
   const resetActiveElements = useBuilderStore(state => state.resetActiveElements);
   const isMultipleItemSelected = useBuilderStore(state => state.activeElements.length > 1);
   const isTextEditorOpen = useBuilderStore(state => state.isTextEditorOpen);
+  const itemAccessor = usePropStore(state => state.itemAccessor);
 
   const requestRef = useRef();
   const [lockAspectRatio, setLockAspectRatio] = useState(false);
@@ -134,6 +136,8 @@ const PageItemResizer = ({
   }), [item.height, item.width, zoom]);
 
   const { isLocked } = item;
+  const accessorItemData = useMemo(() => itemAccessor(item), [item, itemAccessor]);
+  const { actions } = accessorItemData;
 
   return createPortal(
     <ItemPositioner
@@ -156,7 +160,7 @@ const PageItemResizer = ({
         {...resizeStaticProps}
         withClickOutsideWrapperClass={`reportItemResizer-wrapper${isLocked ? ' isLocked' : ''}`}
       />
-      {!isMultipleItemSelected && <DraggableItemActions />}
+      {!isMultipleItemSelected && <DraggableItemActions actions={actions} />}
       {isTextEditorOpen && (
         <TextEditorToolbar
           itemWidth={item.width * zoom}

--- a/src/components/Panels/RightPanel/RightPanel.js
+++ b/src/components/Panels/RightPanel/RightPanel.js
@@ -161,6 +161,19 @@ const RightPanel = () => {
   // Tabs
   const tabsWithSettings = getTabsWithSettings(element, selectedItem, itemAccessor);
   const tabs = Object.keys(tabsWithSettings);
+  const selectedItemActions = useMemo(() => {
+    return itemAccessor(selectedItem)?.actions || { settings: true };
+  }, [itemAccessor, selectedItem]);
+
+  useEffect(() => {
+    if (
+      isRightPanelOpen
+      && editedElement.substr(0, 2) === 'i_'
+      && !selectedItemActions?.settings
+    ) {
+      setIsRightPanelOpen(false);
+    }
+  }, [editedElement, isRightPanelOpen, selectedItemActions, setIsRightPanelOpen]);
 
   useEffect(() => {
     const currentTab = tabs[activeTab.right];


### PR DESCRIPTION
This change enables dynamic control over item-specific actions. An `actions` property, accessed via `itemAccessor`, now dictates the visibility of toolbar buttons (delete, duplicate, lock, settings) and whether double-clicking an item opens the settings panel. If an item's settings action is disabled, the right panel will automatically close.