### PR TITLE
fix(right-panel): correctly handle items without settings

### DIFF
--- a/src/components/Panels/RightPanel/RightPanel.js
+++ b/src/components/Panels/RightPanel/RightPanel.js
@@ -159,21 +159,24 @@ const RightPanel = () => {
   }, [selectedItem, selectedItemID, setActiveTab]);
 
   // Tabs
-  const tabsWithSettings = getTabsWithSettings(element, selectedItem, itemAccessor);
-  const tabs = Object.keys(tabsWithSettings);
   const selectedItemActions = useMemo(() => {
     return itemAccessor(selectedItem)?.actions || { settings: true };
   }, [itemAccessor, selectedItem]);
 
+  const isItemWithoutSettings = editedElement.substr(0, 2) === 'i_' && !selectedItemActions?.settings;
+
+  const tabsWithSettings = useMemo(() => {
+    if (isItemWithoutSettings) return {};
+    return getTabsWithSettings(element, selectedItem, itemAccessor);
+  }, [element, selectedItem, itemAccessor, isItemWithoutSettings]);
+
+  const tabs = Object.keys(tabsWithSettings);
+
   useEffect(() => {
-    if (
-      isRightPanelOpen
-      && editedElement.substr(0, 2) === 'i_'
-      && !selectedItemActions?.settings
-    ) {
+    if (isRightPanelOpen && isItemWithoutSettings) {
       setIsRightPanelOpen(false);
     }
-  }, [editedElement, isRightPanelOpen, selectedItemActions, setIsRightPanelOpen]);
+  }, [isRightPanelOpen, isItemWithoutSettings, setIsRightPanelOpen]);
 
   useEffect(() => {
     const currentTab = tabs[activeTab.right];


### PR DESCRIPTION
Ensures that when an item without settings is selected, the right panel displays no tabs and closes itself if open. This centralizes the logic for identifying such items, improving clarity and maintainability.
